### PR TITLE
Handling File Targeted Configuration and fixing Environment Computed Values

### DIFF
--- a/src/ALZ/Assets/alz-bicep-config/v0.14.1-pre.config.json
+++ b/src/ALZ/Assets/alz-bicep-config/v0.14.1-pre.config.json
@@ -273,7 +273,7 @@
             "Description": "The identifier of the Identity Subscription. (e.g '00000000-0000-0000-0000-000000000000')",
             "Valid": "^( {){0,1}[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(}){0,1}$",
             "Targets": [
-                 {
+                {
                     "Name": "IDENTITY_SUBSCRIPTION_ID",
                     "Destination": "Environment"
                 }
@@ -310,7 +310,7 @@
             "Valid": "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
             "Targets": [
                 {
-                    "Name":"parPolicyAssignmentParameters.value.emailSecurityContact.value",
+                    "Name": "parPolicyAssignmentParameters.value.emailSecurityContact.value",
                     "Destination": "Parameters"
                 }
             ],
@@ -327,7 +327,6 @@
                 }
             ]
         },
-
         "LogAnalyticsResourceId": {
             "Type": "Computed",
             "Value": "/subscriptions/{%ManagementSubscriptionId%}/resourcegroups/alz-logging/providers/microsoft.operationalinsights/workspaces/alz-log-analytics",
@@ -384,7 +383,7 @@
                 }
             ]
         },
-        "VirtualWanName":{
+        "VirtualWanName": {
             "Type": "Computed",
             "Value": "alz-vwan-{%Location%}",
             "Targets": [
@@ -394,7 +393,7 @@
                 }
             ]
         },
-        "FirewallPoliciesName":{
+        "FirewallPoliciesName": {
             "Type": "Computed",
             "Value": "alz-azfwpolicy-{%Location%}",
             "Targets": [
@@ -451,6 +450,36 @@
                 {
                     "Name": "UPSTREAM_RELEASE_VERSION",
                     "Destination": "Environment"
+                }
+            ]
+        },
+        "ConnectivityResourceGroupName": {
+            "Type": "Computed",
+            "Value": "rg-{%Prefix%}-connectivity",
+            "Targets": [
+                {
+                    "Name": "CONNECTIVITY_RESOURCE_GROUP",
+                    "Destination": "Environment"
+                },
+                {
+                    "File": "resourceGroupConnectivity.parameters.all.json",
+                    "Name": "parResourceGroupName.value",
+                    "Destination": "Parameters"
+                }
+            ]
+        },
+        "LoggingResourceGroupName": {
+            "Type": "Computed",
+            "Value": "rg-{%Prefix%}-logging",
+            "Targets": [
+                {
+                    "Name": "LOGGING_RESOURCE_GROUP",
+                    "Destination": "Environment"
+                },
+                {
+                    "File": "resourceGroupLoggingAndSentinel.parameters.all.json",
+                    "Name": "parResourceGroupName.value",
+                    "Destination": "Parameters"
                 }
             ]
         }

--- a/src/ALZ/Private/Build-ALZDeploymentEnvFile.ps1
+++ b/src/ALZ/Private/Build-ALZDeploymentEnvFile.ps1
@@ -24,7 +24,13 @@ function Build-ALZDeploymentEnvFile {
     foreach ($configurationValue in $configuration.PsObject.Properties) {
         foreach ($target in $configurationValue.Value.Targets) {
             if ($target.Destination -eq "Environment") {
-                Add-Content -Path $envFile -Value "$($($target.Name))=`"$($configurationValue.Value.Value)`"" | Out-String | Write-Verbose
+
+                $formattedValue = $configurationValue.Value.Value
+                if ($configurationValue.Value.Type -eq "Computed") {
+                    $formattedValue = Format-TokenizedConfigurationString -tokenizedString $configurationValue.Value.Value -configuration $configuration
+                }
+
+                Add-Content -Path $envFile -Value "$($($target.Name))=`"$formattedValue`"" | Out-String | Write-Verbose
             }
         }
     }

--- a/src/ALZ/Private/Edit-ALZConfigurationFilesInPlace.ps1
+++ b/src/ALZ/Private/Edit-ALZConfigurationFilesInPlace.ps1
@@ -25,6 +25,11 @@ function Edit-ALZConfigurationFilesInPlace {
 
         foreach ($configKey in $configuration.PsObject.Properties) {
             foreach ($target in $configKey.Value.Targets) {
+                # Is this configuration value for this file?
+                $targetedAtThisFile = $null -eq $target.File -or $target.File -eq $file.Name
+                if ($targetedAtThisFile -eq $false) {
+                    continue
+                }
 
                 # Find the appropriate item which will be changed in the Bicep file.
                 # Remove array '[' ']' characters so we can use the index value direct.
@@ -56,7 +61,7 @@ function Edit-ALZConfigurationFilesInPlace {
 
                 } while (($null -ne $bicepConfigNode) -and ($index -lt $propertyNames.Length - 1))
 
-                # If we're here, we've got the object at the bottom of the hierarchy - and we can modify values on it.
+                # If we're here, we can modify this file and we've got an actual object specified by the Name path value - and we can modify values on it.
                 if ($target.Destination -eq "Parameters" -and $null -ne $bicepConfigNode) {
                     $leafPropertyName = $propertyNames[-1]
 


### PR DESCRIPTION
Adding Computed values to Environment, also adding file targeted config to ALZ-BICEP-CONFIG

# Pull Request

## Issue
 
Fixes #38

## Description

Handling 'Computed' values for the Environment file.  (This needs a refactor of how we handle computed values, which I'll do after this change #40)
Supporting file specific replacement values with configuration.
```
{
    Name = {Name of the setting in Bicep config or Environment}
    File = {FileName}
    Destination = {Parameters|Environment}
}
```

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
