### PR TITLE
Remove ALZ management group suffix references

### DIFF
--- a/src/ALZ/Assets/alz-bicep-config/v0.14.1-pre.config.json
+++ b/src/ALZ/Assets/alz-bicep-config/v0.14.1-pre.config.json
@@ -157,19 +157,6 @@
             "DefaultValue": "alz",
             "Valid": "^[a-zA-Z]{3,5}$"
         },
-        "Suffix": {
-            "Type": "UserInput",
-            "Description": "The suffix that will be added to all resources created by this deployment. (e.g. 'test')",
-            "Targets": [
-                {
-                    "Name": "parTopLevelManagementGroupSuffix.value",
-                    "Destination": "Parameters"
-                }
-            ],
-            "Value": "",
-            "DefaultValue": "",
-            "Valid": "^[a-zA-Z]{0,5}$"
-        },
         "Location": {
             "Type": "UserInput",
             "Description": "Deployment location. (e.g. 'uksouth')",

--- a/src/Tests/Unit/Private/Edit-ALZConfigurationFilesInPlace.Tests.ps1
+++ b/src/Tests/Unit/Private/Edit-ALZConfigurationFilesInPlace.Tests.ps1
@@ -35,20 +35,20 @@ InModuleScope 'ALZ' {
                 [Parameter(Mandatory = $true)]
                 [string]$withValue
             )
-                $config = [pscustomobject]@{
-                    Nested     = [pscustomobject]@{
-                        Type        = "Computed"
-                        Description = "A Test Value"
-                        Value       = $withValue
-                        Targets     = @(
-                            [pscustomobject]@{
-                                Name        = $configTarget
-                                Destination = "Parameters"
-                            })
-                    }
+            $config = [pscustomobject]@{
+                Nested = [pscustomobject]@{
+                    Type        = "Computed"
+                    Description = "A Test Value"
+                    Value       = $withValue
+                    Targets     = @(
+                        [pscustomobject]@{
+                            Name        = $configTarget
+                            Destination = "Parameters"
+                        })
                 }
+            }
 
-                return $config
+            return $config
         }
 
         function Format-ExpectedResult {
@@ -69,7 +69,7 @@ InModuleScope 'ALZ' {
         Context 'Edit-ALZConfigurationFilesInPlace should replace the parameters correctly' {
 
             It 'Should replace array values correctly (JSON Object) - first' {
-                $config = Initialize-TestConfiguration -configTarget  "parValue.value.[0]" -withValue "value"
+                $config = Initialize-TestConfiguration -configTarget "parValue.value.[0]" -withValue "value"
 
                 $fileContent = '{
                     "parameters": {
@@ -99,7 +99,7 @@ InModuleScope 'ALZ' {
 
                 $expectedContent = Format-ExpectedResult -expectedJson $expectedContent
 
-                Edit-ALZConfigurationFilesInPlace  -alzEnvironmentDestination '.' -configuration $config
+                Edit-ALZConfigurationFilesInPlace -alzEnvironmentDestination '.' -configuration $config
 
                 Should -Invoke -CommandName Out-File `
                     -ParameterFilter { $FilePath -eq $testFile1Name -and $InputObject -eq $expectedContent } `
@@ -107,7 +107,7 @@ InModuleScope 'ALZ' {
             }
 
             It 'Should replace array an entire array correctly (JSON Object)' {
-                $config = Initialize-TestConfiguration -configTarget  "parValue.value.[1]" -withValue "value"
+                $config = Initialize-TestConfiguration -configTarget "parValue.value.[1]" -withValue "value"
 
                 $fileContent = '{
                     "parameters": {
@@ -137,7 +137,7 @@ InModuleScope 'ALZ' {
 
                 $expectedContent = Format-ExpectedResult -expectedJson $expectedContent
 
-                Edit-ALZConfigurationFilesInPlace  -alzEnvironmentDestination '.' -configuration $config
+                Edit-ALZConfigurationFilesInPlace -alzEnvironmentDestination '.' -configuration $config
 
                 Should -Invoke -CommandName Out-File `
                     -ParameterFilter { $FilePath -eq $testFile1Name -and $InputObject -eq $expectedContent } `
@@ -147,7 +147,7 @@ InModuleScope 'ALZ' {
             It 'Should replace array values correctly (JSON Object) - second' {
 
                 $config = [pscustomobject]@{
-                    Nested     = [pscustomobject]@{
+                    Nested = [pscustomobject]@{
                         Type        = "Computed"
                         Description = "A Test Value"
                         Value       = @(
@@ -185,7 +185,7 @@ InModuleScope 'ALZ' {
 
                 $expectedContent = Format-ExpectedResult -expectedJson $expectedContent
 
-                Edit-ALZConfigurationFilesInPlace  -alzEnvironmentDestination '.' -configuration $config
+                Edit-ALZConfigurationFilesInPlace -alzEnvironmentDestination '.' -configuration $config
 
                 Should -Invoke -CommandName Out-File `
                     -ParameterFilter { $FilePath -eq $testFile1Name -and $InputObject -eq $expectedContent } `
@@ -193,7 +193,7 @@ InModuleScope 'ALZ' {
             }
 
             It 'Should not write to files that havent been changed.' {
-                $config = Initialize-TestConfiguration -configTarget  "DoesnotExist.value" -withValue "value"
+                $config = Initialize-TestConfiguration -configTarget "DoesnotExist.value" -withValue "value"
 
                 $fileContent = '{
                     "parameters": {
@@ -207,7 +207,7 @@ InModuleScope 'ALZ' {
                     $fileContent
                 }
 
-                Edit-ALZConfigurationFilesInPlace  -alzEnvironmentDestination '.' -configuration $config
+                Edit-ALZConfigurationFilesInPlace -alzEnvironmentDestination '.' -configuration $config
 
                 Should -Invoke -CommandName Out-File `
                     -Scope It `
@@ -215,7 +215,7 @@ InModuleScope 'ALZ' {
             }
 
             It 'Should replace simple values correctly (Bicep Object)' {
-                $config = Initialize-TestConfiguration -configTarget  "parValue.value" -withValue "value"
+                $config = Initialize-TestConfiguration -configTarget "parValue.value" -withValue "value"
 
                 $fileContent = '{
                     "parameters": {
@@ -239,7 +239,7 @@ InModuleScope 'ALZ' {
 
                 $expectedContent = Format-ExpectedResult -expectedJson $expectedContent
 
-                Edit-ALZConfigurationFilesInPlace  -alzEnvironmentDestination '.' -configuration $config
+                Edit-ALZConfigurationFilesInPlace -alzEnvironmentDestination '.' -configuration $config
 
                 Should -Invoke -CommandName Out-File `
                     -ParameterFilter { $FilePath -eq $testFile1Name -and $InputObject -eq $expectedContent } `
@@ -247,7 +247,7 @@ InModuleScope 'ALZ' {
             }
 
             It "Should replace 'Parameter' destinations to nested array objects correctly" {
-                $config = Initialize-TestConfiguration -configTarget  "parNested.value.[0].parChildValue.value" -withValue "nested"
+                $config = Initialize-TestConfiguration -configTarget "parNested.value.[0].parChildValue.value" -withValue "nested"
 
                 $fileContent = '{
                     "parameters": {
@@ -279,7 +279,7 @@ InModuleScope 'ALZ' {
 
                 $expectedContent = Format-ExpectedResult -expectedJson $expectedContent
 
-                Edit-ALZConfigurationFilesInPlace  -alzEnvironmentDestination '.' -configuration $config
+                Edit-ALZConfigurationFilesInPlace -alzEnvironmentDestination '.' -configuration $config
 
                 Should -Invoke -CommandName Out-File `
                     -ParameterFilter { $FilePath -eq $testFile1Name -and $InputObject -eq $expectedContent } `
@@ -287,7 +287,7 @@ InModuleScope 'ALZ' {
             }
 
             It 'Should replace nested values correctly (Plain JSON Object)' {
-                $config = Initialize-TestConfiguration -configTarget  "parNested.value.parChildValue" -withValue "nested"
+                $config = Initialize-TestConfiguration -configTarget "parNested.value.parChildValue" -withValue "nested"
 
                 $fileContent = '{
                     "parameters": {
@@ -315,7 +315,7 @@ InModuleScope 'ALZ' {
 
                 $expectedContent = Format-ExpectedResult -expectedJson $expectedContent
 
-                Edit-ALZConfigurationFilesInPlace  -alzEnvironmentDestination '.' -configuration $config
+                Edit-ALZConfigurationFilesInPlace -alzEnvironmentDestination '.' -configuration $config
 
                 Should -Invoke -CommandName Out-File `
                     -ParameterFilter { $FilePath -eq $testFile1Name -and $InputObject -eq $expectedContent } `
@@ -323,7 +323,7 @@ InModuleScope 'ALZ' {
             }
 
             It 'Should replace nested values correctly (Bicep Object)' {
-                $config = Initialize-TestConfiguration -configTarget  "parNested.value.parChildValue.value" -withValue "nested"
+                $config = Initialize-TestConfiguration -configTarget "parNested.value.parChildValue.value" -withValue "nested"
 
                 $fileContent = '{
                     "parameters": {
@@ -355,7 +355,7 @@ InModuleScope 'ALZ' {
 
                 $expectedContent = Format-ExpectedResult -expectedJson $expectedContent
 
-                Edit-ALZConfigurationFilesInPlace  -alzEnvironmentDestination '.' -configuration $config
+                Edit-ALZConfigurationFilesInPlace -alzEnvironmentDestination '.' -configuration $config
 
                 Should -Invoke -CommandName Out-File `
                     -ParameterFilter { $FilePath -eq $testFile1Name -and $InputObject -eq $expectedContent } `
@@ -377,16 +377,6 @@ InModuleScope 'ALZ' {
                             })
                         Value        = "test"
                         DefaultValue = "alz"
-                    }
-                    Suffix      = [pscustomobject]@{
-                        Description  = "The suffix that will be added to all resources created by this deployment."
-                        Targets      = @(
-                            [pscustomobject]@{
-                                Name        = "parTopLevelManagementGroupSuffix.value"
-                                Destination = "Parameters"
-                            })
-                        Value        = "bla"
-                        DefaultValue = ""
                     }
                     Location    = [pscustomobject]@{
                         Description   = "Deployment location."
@@ -434,9 +424,6 @@ InModuleScope 'ALZ' {
                 }'
                 $secondFileContent = '{
                     "parameters": {
-                        "parTopLevelManagementGroupSuffix": {
-                            "value": ""
-                        },
                         "parLocation": {
                             "value": ""
                         }
@@ -460,7 +447,7 @@ InModuleScope 'ALZ' {
                     $secondFileContent
                 }
 
-                Edit-ALZConfigurationFilesInPlace  -alzEnvironmentDestination '.' -configuration $defaultConfig
+                Edit-ALZConfigurationFilesInPlace -alzEnvironmentDestination '.' -configuration $defaultConfig
 
                 Should -Invoke -CommandName Out-File -Scope It -Times 2
 
@@ -475,7 +462,6 @@ InModuleScope 'ALZ' {
                 Should -Invoke -CommandName Out-File -ParameterFilter { $FilePath -eq "test1.parameters.json" -and $InputObject -eq $contentStringAfterParsing } -Scope It
 
                 $contentAfterParsing = ConvertFrom-Json -InputObject $secondFileContent -AsHashtable
-                $contentAfterParsing.parameters.parTopLevelManagementGroupSuffix.value = 'bla'
                 $contentAfterParsing.parameters.parLocation.value = 'eastus'
 
                 $contentStringAfterParsing = ConvertTo-Json -InputObject $contentAfterParsing
@@ -485,11 +471,11 @@ InModuleScope 'ALZ' {
 
             It 'Computed, Processed array values replace values correctly' {
                 $config = [pscustomobject]@{
-                    Nested     = [pscustomobject]@{
+                    Nested = [pscustomobject]@{
                         Type        = "Computed"
                         Description = "A Test Value"
-                        Process = '@($args | Select-Object -Unique)'
-                        Value   = @(
+                        Process     = '@($args | Select-Object -Unique)'
+                        Value       = @(
                             "1",
                             "1",
                             "3"
@@ -524,7 +510,7 @@ InModuleScope 'ALZ' {
 
                 $expectedContent = Format-ExpectedResult -expectedJson $expectedContent
 
-                Edit-ALZConfigurationFilesInPlace  -alzEnvironmentDestination '.' -configuration $config
+                Edit-ALZConfigurationFilesInPlace -alzEnvironmentDestination '.' -configuration $config
 
                 Should -Invoke -CommandName Out-File `
                     -ParameterFilter { $FilePath -eq $testFile1Name -and $InputObject -eq $expectedContent } `
@@ -533,11 +519,11 @@ InModuleScope 'ALZ' {
 
             It 'Computed, Processed array values replace values correctly in a case insensitive deduplication.' {
                 $config = [pscustomobject]@{
-                    Nested     = [pscustomobject]@{
+                    Nested = [pscustomobject]@{
                         Type        = "Computed"
                         Description = "A Test Value"
-                        Process = '@($args | ForEach-Object { $_.ToLower() } | Select-Object -Unique)'
-                        Value   = @(
+                        Process     = '@($args | ForEach-Object { $_.ToLower() } | Select-Object -Unique)'
+                        Value       = @(
                             "A",
                             "a",
                             "A",
@@ -573,7 +559,7 @@ InModuleScope 'ALZ' {
 
                 $expectedContent = Format-ExpectedResult -expectedJson $expectedContent
 
-                Edit-ALZConfigurationFilesInPlace  -alzEnvironmentDestination '.' -configuration $config
+                Edit-ALZConfigurationFilesInPlace -alzEnvironmentDestination '.' -configuration $config
 
                 Should -Invoke -CommandName Out-File `
                     -ParameterFilter { $FilePath -eq $testFile1Name -and $InputObject -eq $expectedContent } `
@@ -582,11 +568,11 @@ InModuleScope 'ALZ' {
 
             It 'Computed, Processed array values replace values correctly and keep array type when only one item remains.' {
                 $config = [pscustomobject]@{
-                    Nested     = [pscustomobject]@{
+                    Nested = [pscustomobject]@{
                         Type        = "Computed"
                         Description = "A Test Value"
-                        Process = '@($args | Select-Object -Unique)'
-                        Value   = @(
+                        Process     = '@($args | Select-Object -Unique)'
+                        Value       = @(
                             "1",
                             "1",
                             "1"
@@ -621,7 +607,7 @@ InModuleScope 'ALZ' {
 
                 $expectedContent = Format-ExpectedResult -expectedJson $expectedContent
 
-                Edit-ALZConfigurationFilesInPlace  -alzEnvironmentDestination '.' -configuration $config
+                Edit-ALZConfigurationFilesInPlace -alzEnvironmentDestination '.' -configuration $config
 
                 Should -Invoke -CommandName Out-File `
                     -ParameterFilter { $FilePath -eq $testFile1Name -and $InputObject -eq $expectedContent } `
@@ -630,10 +616,10 @@ InModuleScope 'ALZ' {
 
             It 'Computed, Processed values replace values correctly' {
                 $config = [pscustomobject]@{
-                    Nested     = [pscustomobject]@{
+                    Nested = [pscustomobject]@{
                         Type        = "Computed"
                         Description = "A Test Value"
-                        Process = '($args[0] -eq "eastus") ? "eastus2" : ($args[0] -eq "eastus2") ? "eastus" : $args[0]'
+                        Process     = '($args[0] -eq "eastus") ? "eastus2" : ($args[0] -eq "eastus2") ? "eastus" : $args[0]'
                         Value       = "eastus"
                         Targets     = @(
                             [pscustomobject]@{
@@ -665,7 +651,7 @@ InModuleScope 'ALZ' {
 
                 $expectedContent = Format-ExpectedResult -expectedJson $expectedContent
 
-                Edit-ALZConfigurationFilesInPlace  -alzEnvironmentDestination '.' -configuration $config
+                Edit-ALZConfigurationFilesInPlace -alzEnvironmentDestination '.' -configuration $config
 
                 Should -Invoke -CommandName Out-File `
                     -ParameterFilter { $FilePath -eq $testFile1Name -and $InputObject -eq $expectedContent } `
@@ -674,10 +660,10 @@ InModuleScope 'ALZ' {
 
             It 'Computed, Processed values replace values correctly' {
                 $config = [pscustomobject]@{
-                    Nested     = [pscustomobject]@{
+                    Nested = [pscustomobject]@{
                         Type        = "Computed"
                         Description = "A Test Value"
-                        Process = '($args[0] -eq "goodbye") ? "Hello" : "Goodbye"'
+                        Process     = '($args[0] -eq "goodbye") ? "Hello" : "Goodbye"'
                         Value       = "goodbye"
                         Targets     = @(
                             [pscustomobject]@{
@@ -709,7 +695,7 @@ InModuleScope 'ALZ' {
 
                 $expectedContent = Format-ExpectedResult -expectedJson $expectedContent
 
-                Edit-ALZConfigurationFilesInPlace  -alzEnvironmentDestination '.' -configuration $config
+                Edit-ALZConfigurationFilesInPlace -alzEnvironmentDestination '.' -configuration $config
 
                 Should -Invoke -CommandName Out-File `
                     -ParameterFilter { $FilePath -eq $testFile1Name -and $InputObject -eq $expectedContent } `
@@ -718,7 +704,7 @@ InModuleScope 'ALZ' {
 
             It 'Multiple files with file specific configuration should be changed correctly' {
                 $defaultConfig = [pscustomobject]@{
-                    Value1      = [pscustomobject]@{
+                    Value1 = [pscustomobject]@{
                         Description  = "The prefix that will be added to all resources created by this deployment."
                         Targets      = @(
                             [pscustomobject]@{
@@ -729,7 +715,7 @@ InModuleScope 'ALZ' {
                         Value        = "value1"
                         DefaultValue = "alz"
                     }
-                    Value2      = [pscustomobject]@{
+                    Value2 = [pscustomobject]@{
                         Description  = "The prefix that will be added to all resources created by this deployment."
                         Targets      = @(
                             [pscustomobject]@{
@@ -760,11 +746,11 @@ InModuleScope 'ALZ' {
                 Mock -CommandName Get-ChildItem -ParameterFilter { $Path -match 'config$' } -MockWith {
                     @(
                         [PSCustomObject]@{
-                            Name = 'test1.parameters.json'
+                            Name     = 'test1.parameters.json'
                             FullName = 'test1.parameters.json'
                         },
                         [PSCustomObject]@{
-                            Name = 'test2.parameters.json'
+                            Name     = 'test2.parameters.json'
                             FullName = 'test2.parameters.json'
                         }
                     )
@@ -777,7 +763,7 @@ InModuleScope 'ALZ' {
                     $secondFileContent
                 }
 
-                Edit-ALZConfigurationFilesInPlace  -alzEnvironmentDestination '.' -configuration $defaultConfig
+                Edit-ALZConfigurationFilesInPlace -alzEnvironmentDestination '.' -configuration $defaultConfig
 
                 Should -Invoke -CommandName Out-File -Scope It -Times 2
 

--- a/src/Tests/Unit/Private/Request-ALZEnvironmentConfig.Tests.ps1
+++ b/src/Tests/Unit/Private/Request-ALZEnvironmentConfig.Tests.ps1
@@ -5,24 +5,24 @@ $ModuleName = 'ALZ'
 $PathToManifest = [System.IO.Path]::Combine('..', '..', '..', $ModuleName, "$ModuleName.psd1")
 #-------------------------------------------------------------------------
 if (Get-Module -Name $ModuleName -ErrorAction 'SilentlyContinue') {
-    #if the module is already in memory, remove it
-    Remove-Module -Name $ModuleName -Force
+   #if the module is already in memory, remove it
+   Remove-Module -Name $ModuleName -Force
 }
 Import-Module $PathToManifest -Force
 #-------------------------------------------------------------------------
 
 InModuleScope 'ALZ' {
-    Describe 'Request-ALZEnvironmentConfig Private Function Tests' -Tag Unit {
-        BeforeAll {
-            $WarningPreference = 'SilentlyContinue'
-            $ErrorActionPreference = 'SilentlyContinue'
-        }
-        Context 'Request-ALZEnvironmentConfig should request CLI input for configuration.' {
-            It 'Based on the configuration object' {
+   Describe 'Request-ALZEnvironmentConfig Private Function Tests' -Tag Unit {
+      BeforeAll {
+         $WarningPreference = 'SilentlyContinue'
+         $ErrorActionPreference = 'SilentlyContinue'
+      }
+      Context 'Request-ALZEnvironmentConfig should request CLI input for configuration.' {
+         It 'Based on the configuration object' {
 
-                Mock -CommandName Request-ConfigurationValue
+            Mock -CommandName Request-ConfigurationValue
 
-                $config = @'
+            $config = @'
                 {
                     "parameters":{
                        "Prefix":{
@@ -35,29 +35,16 @@ InModuleScope 'ALZ' {
                              }
                           ],
                           "DefaultValue":"alz"
-                       },
-                       "Suffix":{
-                          "Type":"UserInput",
-                          "Description":"The suffix that will be added to all resources created by this deployment. (e.g. 'test')",
-                          "Targets":[
-                             {
-                                "Name":"parTopLevelManagementGroupSuffix",
-                                "Destination":"Parameters"
-                             }
-                          ],
-                          "Value":"",
-                          "DefaultValue":"",
-                          "Valid":"^[a-zA-Z]{0,5}$"
                        }
                     }
                  }
 '@ | ConvertFrom-Json
 
-                Request-ALZEnvironmentConfig -configurationParameters $config.Parameters
+            Request-ALZEnvironmentConfig -configurationParameters $config.Parameters
 
-                Should -Invoke Request-ConfigurationValue -Scope It -Times 2 -Exactly
-            }
+            Should -Invoke Request-ConfigurationValue -Scope It -Times 1 -Exactly
+         }
 
-        }
-    }
+      }
+   }
 }


### PR DESCRIPTION
# Pull Request

## Issue

Issue #, if available: #48

## Description

Description of changes:
- Remove management group suffix input requirement due to limitations with dependent ALZ-Bicep modules
- General formatting fixes for related files

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
