### PR TITLE
management group id check

### DIFF
--- a/src/ALZ/Assets/alz-bicep-config/v0.14.0.config.json
+++ b/src/ALZ/Assets/alz-bicep-config/v0.14.0.config.json
@@ -159,7 +159,7 @@
             ],
             "Value": "",
             "DefaultValue": "alz",
-            "Valid": "^[a-zA-Z]{2,5}$"
+            "Valid": "^[a-zA-Z]{2,5}(-[a-zA-Z]{2,5})?$"
         },
         "Location": {
             "Type": "UserInput",

--- a/src/ALZ/Assets/alz-bicep-config/v0.14.0.config.json
+++ b/src/ALZ/Assets/alz-bicep-config/v0.14.0.config.json
@@ -159,7 +159,7 @@
             ],
             "Value": "",
             "DefaultValue": "alz",
-            "Valid": "^[a-zA-Z]{2,5}(-[a-zA-Z]{2,5})?$"
+            "Valid": "^[a-zA-Z0-9]{2,10}(-[a-zA-Z0-9]{2,10})?$"
         },
         "Location": {
             "Type": "UserInput",

--- a/src/Tests/Unit/Private/Request-ConfigurationValue.Tests.ps1
+++ b/src/Tests/Unit/Private/Request-ConfigurationValue.Tests.ps1
@@ -85,7 +85,7 @@ InModuleScope 'ALZ' {
                     Names        = @("parTopLevelManagementGroupPrefix", "parCompanyPrefix")
                     Value        = ""
                     DefaultValue = "alz"
-                    Valid        = "^[a-zA-Z]{3,5}$"
+                    Valid        = "^[a-zA-Z0-9]{2,10}(-[a-zA-Z0-9]{2,10})?$"
                 }
 
                 Request-ConfigurationValue -configName "prefix" -configValue $configValue -withRetries $false


### PR DESCRIPTION
# Pull Request

## Issue

Issue #57 

## Description

Description of changes:
The current regex does not allow a management group id like *iac-alz*.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
