### PR TITLE
Bug: Amended network params

### DIFF
--- a/src/ALZ/Assets/alz-bicep-config/v0.14.0.config.json
+++ b/src/ALZ/Assets/alz-bicep-config/v0.14.0.config.json
@@ -390,9 +390,7 @@
         },
         "HubNetworkName": {
             "Type": "Computed",
-            "Value": [
-                "alz-hub-{%Location%}"
-            ],
+            "Value": "alz-hub-{%Location%}",
             "Targets": [
                 {
                     "Name": "parHubNetworkName.value",
@@ -422,9 +420,7 @@
         },
         "AzFirewallName": {
             "Type": "Computed",
-            "Value": [
-                "alz-azfw-{%Location%}"
-            ],
+            "Value": "alz-azfw-{%Location%}",
             "Targets": [
                 {
                     "Name": "parAzFirewallName.value",


### PR DESCRIPTION
# Pull Request

## Issue

Hub network deployment failing as its passing an array rather than a string.

Affected params are parHubNetworkName and parAzFirewallName

![image](https://github.com/Azure/ALZ-PowerShell-Module/assets/78753426/05c8d89b-a496-43b7-95dd-60439812a605)

## Description

Amended code to declare a string rather than an array. Tested manually by updating the code on the fly.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
