### PR TITLE
Add edit-lineendings function

### DIFF
--- a/src/ALZ/ALZ.psd1
+++ b/src/ALZ/ALZ.psd1
@@ -73,6 +73,7 @@
         'Get-ALZGithubRelease'
         'New-ALZEnvironment'
         'Test-ALZRequirement'
+        'Edit-LineEnding'
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/src/ALZ/Public/Edit-LineEnding.ps1
+++ b/src/ALZ/Public/Edit-LineEnding.ps1
@@ -1,0 +1,41 @@
+enum LineEndingTypes {
+    Darwin
+    Unix
+    Win
+}
+
+function Edit-LineEnding {
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    [OutputType([String[]])]
+    param (
+        [Parameter(ValueFromPipeline = $true)]
+        [String[]]$InputText,
+        [Parameter()][LineEndingTypes]$LineEnding = "Unix"
+    )
+
+    Begin {
+
+        Switch ("$LineEnding".ToLower()) {
+            "darwin" { $eol = "`r" }
+            "unix" { $eol = "`n" }
+            "win" { $eol = "`r`n" }
+        }
+
+    }
+
+    Process {
+
+        [String[]]$outputText += $InputText |
+            ForEach-Object { $_ -replace "`r`n", "`n" } |
+            ForEach-Object { $_ -replace "`r", "`n" } |
+            ForEach-Object { $_ -replace "`n", "$eol" }
+
+    }
+
+    End {
+
+        return $outputText
+
+    }
+
+}

--- a/src/Tests/Unit/Public/Edit-LineEnding.Tests.ps1
+++ b/src/Tests/Unit/Public/Edit-LineEnding.Tests.ps1
@@ -1,0 +1,89 @@
+#-------------------------------------------------------------------------
+Set-Location -Path $PSScriptRoot
+#-------------------------------------------------------------------------
+$ModuleName = 'ALZ'
+$PathToManifest = [System.IO.Path]::Combine('..', '..', '..', $ModuleName, "$ModuleName.psd1")
+#-------------------------------------------------------------------------
+if (Get-Module -Name $ModuleName -ErrorAction 'SilentlyContinue') {
+    #if the module is already in memory, remove it
+    Remove-Module -Name $ModuleName -Force
+}
+Import-Module $PathToManifest -Force
+#-------------------------------------------------------------------------
+
+InModuleScope 'ALZ' {
+    Describe "Edit-LineEnding" {
+        BeforeAll {
+            $WarningPreference = 'SilentlyContinue'
+            $ErrorActionPreference = 'SilentlyContinue'
+        }
+        Context "When converting to Unix line endings" {
+            It "Converts Windows line endings to Unix" {
+                $inputText = "Hello`r`nWorld`r`n"
+                $expectedOutput = "Hello`nWorld`n"
+                $result = Edit-LineEnding -InputText $inputText -LineEnding Unix
+                $result | Should -Be $expectedOutput
+            }
+
+            It "Converts mixed line endings to Unix" {
+                $inputText = "Hello`rWorld`n"
+                $expectedOutput = "Hello`nWorld`n"
+                $result = Edit-LineEnding -InputText $inputText -LineEnding Unix
+                $result | Should -Be $expectedOutput
+            }
+
+            It "Does not modify Unix line endings" {
+                $inputText = "Hello`nWorld`n"
+                $expectedOutput = "Hello`nWorld`n"
+                $result = Edit-LineEnding -InputText $inputText -LineEnding Unix
+                $result | Should -Be $expectedOutput
+            }
+        }
+
+        Context "When converting to Windows line endings" {
+            It "Converts Unix line endings to Windows" {
+                $inputText = "Hello`nWorld`n"
+                $expectedOutput = "Hello`r`nWorld`r`n"
+                $result = Edit-LineEnding -InputText $inputText -LineEnding Win
+                $result | Should -Be $expectedOutput
+            }
+
+            It "Converts mixed line endings to Windows" {
+                $inputText = "Hello`rWorld`n"
+                $expectedOutput = "Hello`r`nWorld`r`n"
+                $result = Edit-LineEnding -InputText $inputText -LineEnding Win
+                $result | Should -Be $expectedOutput
+            }
+
+            It "Does not modify Windows line endings" {
+                $inputText = "Hello`r`nWorld`r`n"
+                $expectedOutput = "Hello`r`nWorld`r`n"
+                $result = Edit-LineEnding -InputText $inputText -LineEnding Win
+                $result | Should -Be $expectedOutput
+            }
+        }
+
+        Context "When converting to Darwin line endings" {
+            It "Converts Unix line endings to Darwin" {
+                $inputText = "Hello`nWorld`n"
+                $expectedOutput = "Hello`rWorld`r"
+                $result = Edit-LineEnding -InputText $inputText -LineEnding Darwin
+                $result | Should -Be $expectedOutput
+            }
+
+            It "Converts mixed line endings to Darwin" {
+                $inputText = "Hello`rWorld`n"
+                $expectedOutput = "Hello`rWorld`r"
+                $result = Edit-LineEnding -InputText $inputText -LineEnding Darwin
+                $result | Should -Be $expectedOutput
+            }
+
+            It "Does not modify Darwin line endings" {
+                $inputText = "Hello`rWorld`r"
+                $expectedOutput = "Hello`rWorld`r"
+                $result = Edit-LineEnding -InputText $inputText -LineEnding Darwin
+                $result | Should -Be $expectedOutput
+            }
+        }
+    }
+}


### PR DESCRIPTION
As part of simplifying ALZ Bicep users experiences with custom policies, I have added the `Edit-LineEnding` function from the `ALZ.Tools` local module in the `Azure/Enterprise-Scale` module to this module as a public function. Therefore any customer using the `ALZ` module, here, will automatically have it available to them without having to install another module

https://github.com/Azure/ALZ-Bicep/issues/583