### PR TITLE
feature: treat empty default as valid

### DIFF
--- a/src/ALZ/Private/New-ALZEnvironmentTerraform.ps1
+++ b/src/ALZ/Private/New-ALZEnvironmentTerraform.ps1
@@ -53,7 +53,7 @@ function New-ALZEnvironmentTerraform {
         Write-InformationColored "Got configuration and downloaded alz-terraform-accelerator Terraform module version $release to $alzEnvironmentDestination" -ForegroundColor Green -InformationAction Continue
 
         # Getting the user input for the bootstrap module
-        $bootstrapConfiguration = Request-ALZEnvironmentConfig -configurationParameters $bootstrapParameters -respectOrdering -userInputOverrides $userInputOverrides
+        $bootstrapConfiguration = Request-ALZEnvironmentConfig -configurationParameters $bootstrapParameters -respectOrdering -userInputOverrides $userInputOverrides -treatEmptyDefaultAsValid $true
 
         # Getting the configuration for the starter module user input
         $starterTemplate = $bootstrapConfiguration.PsObject.Properties["starter_module"].Value.Value
@@ -64,7 +64,7 @@ function New-ALZEnvironmentTerraform {
         Write-InformationColored "The following inputs are specific to the '$starterTemplate' starter module that you selected..." -ForegroundColor Green -InformationAction Continue
 
         # Getting the user input for the starter module
-        $starterModuleConfiguration = Request-ALZEnvironmentConfig -configurationParameters $starterModuleParameters -respectOrdering -userInputOverrides $userInputOverrides
+        $starterModuleConfiguration = Request-ALZEnvironmentConfig -configurationParameters $starterModuleParameters -respectOrdering -userInputOverrides $userInputOverrides -treatEmptyDefaultAsValid $true
 
         # Getting subscription ids
         Import-SubscriptionData -starterModuleConfiguration $starterModuleConfiguration -bootstrapConfiguration $bootstrapConfiguration

--- a/src/ALZ/Private/Request-ALZEnvironmentConfig.ps1
+++ b/src/ALZ/Private/Request-ALZEnvironmentConfig.ps1
@@ -6,7 +6,9 @@ function Request-ALZEnvironmentConfig {
         [Parameter(Mandatory = $false)]
         [switch] $respectOrdering,
         [Parameter(Mandatory = $false)]
-        [PSCustomObject] $userInputOverrides = $null
+        [PSCustomObject] $userInputOverrides = $null,
+        [Parameter(Mandatory = $false)]
+        [System.Boolean] $treatEmptyDefaultAsValid = $false
     )
     <#
     .SYNOPSIS
@@ -37,10 +39,10 @@ function Request-ALZEnvironmentConfig {
                 if($null -ne $userInputOverride) {
                     $configurationValue.Value.Value = $userInputOverride.Value
                 } else {
-                    Request-ConfigurationValue $configurationValue.Name $configurationValue.Value
+                    Request-ConfigurationValue -configName $configurationValue.Name -configValue $configurationValue.Value -treatEmptyDefaultAsValid $treatEmptyDefaultAsValid
                 }
             } else {
-                Request-ConfigurationValue $configurationValue.Name $configurationValue.Value
+                Request-ConfigurationValue -configName $configurationValue.Name -configValue $configurationValue.Value -treatEmptyDefaultAsValid $treatEmptyDefaultAsValid
             }
         }
     }

--- a/src/ALZ/Private/Request-ConfigurationValue.ps1
+++ b/src/ALZ/Private/Request-ConfigurationValue.ps1
@@ -7,7 +7,10 @@ function Request-ConfigurationValue {
         [object] $configValue,
 
         [Parameter(Mandatory = $false)]
-        [System.Boolean] $withRetries = $true
+        [System.Boolean] $withRetries = $true,
+
+        [Parameter(Mandatory = $false)]
+        [System.Boolean] $treatEmptyDefaultAsValid = $false
     )
 
     #if the file has a script - execute it:
@@ -51,7 +54,13 @@ function Request-ConfigurationValue {
 
         $hasNotSpecifiedValue = ($null -eq $configValue.Value -or "" -eq $configValue.Value) -and ($configValue.Value -ne $configValue.DefaultValue)
         $isDisallowedValue = $hasAllowedValues -and $allowedValues.Contains($configValue.Value) -eq $false
-        $isNotValid = $hasValidator -and $configValue.Value -match $configValue.Valid -eq $false
+        $skipValidationForEmptyDefault = $treatEmptyDefaultAsValid -and $hasDefaultValue -and $defaultValue -eq "" -and $configValue.Value -eq ""
+        
+        if($skipValidationForEmptyDefault) {
+            $isNotValid = $false
+        } else {
+            $isNotValid = $hasValidator -and $configValue.Value -match $configValue.Valid -eq $false
+        }
 
         if ($hasNotSpecifiedValue -or $isDisallowedValue -or $isNotValid) {
             Write-InformationColored "Please specify a valid value for this field." -ForegroundColor Red -InformationAction Continue

--- a/src/ALZ/Public/Get-ALZGithubRelease.ps1
+++ b/src/ALZ/Public/Get-ALZGithubRelease.ps1
@@ -50,7 +50,7 @@ function Get-ALZGithubRelease {
 
     # Get releases on repo
     $repoReleasesUrl = "https://api.github.com/repos/$repoOrgPlusRepo/releases"
-    $allRepoReleases = Invoke-RestMethod $repoReleasesUrl
+    $allRepoReleases = Invoke-RestMethod $repoReleasesUrl -RetryIntervalSec 3 -MaximumRetryCount 100
 
     Write-Verbose "=====> All available releases on GitHub Repo: $repoOrgPlusRepo"
     $allRepoReleases | Select-Object name, tag_name, published_at, prerelease, draft, html_url | Format-Table -AutoSize | Out-String | Write-Verbose
@@ -112,7 +112,7 @@ function Get-ALZGithubRelease {
         if ($null -eq $contentInReleaseDirectory) {
             Write-Verbose "===> Pulling and extracting release $($release.tag_name) into $releaseDirectory"
             New-Item -ItemType Directory -Path "$releaseDirectory/tmp" | Out-String | Write-Verbose
-            Invoke-WebRequest -Uri "https://github.com/$repoOrgPlusRepo/archive/refs/tags/$($release.tag_name).zip" -OutFile "$releaseDirectory/tmp/$($release.tag_name).zip" | Out-String | Write-Verbose
+            Invoke-WebRequest -Uri "https://github.com/$repoOrgPlusRepo/archive/refs/tags/$($release.tag_name).zip" -OutFile "$releaseDirectory/tmp/$($release.tag_name).zip" -RetryIntervalSec 3 -MaximumRetryCount 100 | Out-String | Write-Verbose
             Expand-Archive -Path "$releaseDirectory/tmp/$($release.tag_name).zip" -DestinationPath "$releaseDirectory/tmp/extracted" | Out-String | Write-Verbose
             $extractedSubFolder = Get-ChildItem -Path "$releaseDirectory/tmp/extracted" -Directory
 


### PR DESCRIPTION
# Pull Request

## Issue

Issue #, if available: N/A

## Description

Description of changes: 

For Terraform there are some cases where we want to either provide an empty value or a valid string. E.g. an empty string or a subscription id. The existing implementation did not handle this, so added a parameter to support this scenario.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
