### PR TITLE
Update Get-ALZGithubRelease.ps1

### DIFF
--- a/src/ALZ/Public/Get-ALZGithubRelease.ps1
+++ b/src/ALZ/Public/Get-ALZGithubRelease.ps1
@@ -55,11 +55,11 @@ function Get-ALZGithubRelease {
     $allRepoReleases = @()
     do {
         Write-Verbose "=====> Retrieving page $page of releases on GitHub Repo: $repoOrgPlusRepo"
-        $releases = Invoke-RestMethod ($repoReleasesUrl + "?per_page=$perPage&page=$page") -RetryIntervalSec 3 -MaximumRetryCount 100
+        $results = Invoke-RestMethod ($repoReleasesUrl + "?per_page=$perPage&page=$page") -RetryIntervalSec 3 -MaximumRetryCount 100
         $allRepoReleases += $releases
         $page++
     }
-    while ($releases.count -eq $perPage)
+    while ($results.count -eq $perPage)
 
     Write-Verbose "=====> All available releases on GitHub Repo: $repoOrgPlusRepo"
     $allRepoReleases | Select-Object name, tag_name, published_at, prerelease, draft, html_url | Format-Table -AutoSize | Out-String | Write-Verbose

--- a/src/ALZ/Public/Get-ALZGithubRelease.ps1
+++ b/src/ALZ/Public/Get-ALZGithubRelease.ps1
@@ -56,7 +56,7 @@ function Get-ALZGithubRelease {
     do {
         Write-Verbose "=====> Retrieving page $page of releases on GitHub Repo: $repoOrgPlusRepo"
         $results = Invoke-RestMethod ($repoReleasesUrl + "?per_page=$perPage&page=$page") -RetryIntervalSec 3 -MaximumRetryCount 100
-        $allRepoReleases += $releases
+        $allRepoReleases += $results
         $page++
     }
     while ($results.count -eq $perPage)

--- a/src/ALZ/Public/Get-ALZGithubRelease.ps1
+++ b/src/ALZ/Public/Get-ALZGithubRelease.ps1
@@ -50,7 +50,16 @@ function Get-ALZGithubRelease {
 
     # Get releases on repo
     $repoReleasesUrl = "https://api.github.com/repos/$repoOrgPlusRepo/releases"
-    $allRepoReleases = Invoke-RestMethod $repoReleasesUrl -RetryIntervalSec 3 -MaximumRetryCount 100
+    $perPage = 30
+    $page = 1
+    $allRepoReleases = @()
+    do {
+        Write-Verbose "=====> Retrieving page $page of releases on GitHub Repo: $repoOrgPlusRepo"
+        $releases = Invoke-RestMethod ($repoReleasesUrl + "?per_page=$perPage&page=$page") -RetryIntervalSec 3 -MaximumRetryCount 100
+        $allRepoReleases += $releases
+        $page++
+    }
+    while ($releases.count -eq $perPage)
 
     Write-Verbose "=====> All available releases on GitHub Repo: $repoOrgPlusRepo"
     $allRepoReleases | Select-Object name, tag_name, published_at, prerelease, draft, html_url | Format-Table -AutoSize | Out-String | Write-Verbose


### PR DESCRIPTION
Add support for pagination of Github releases

# Pull Request

## Issue

Fixes #85

## Description

Description of changes: Add support for pagination when calling the releases endpoint on the GitHub API.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
