### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,15 @@ The goal of this project it is to make easy to get started with Azure Landing Zo
 
 ### Prerequisites
 
-In order to use this module you will need PowerShell 7.1 or higher.
+In order to use this module you will need PowerShell 7.1 or higher.  
+Download and install the latest version from the official PowerShell GitHub releases page: [PowerShell Releases](https://github.com/PowerShell/PowerShell/releases)
 
+To make PowerShell 7 your default instead of version 5, consider setting an alias.
+   Open a PowerShell session and run the following command:
+   ```powershell
+   $PSVersionTable.PSVersion
+   Set-Alias powershell pwsh
+  ```
 ### Installation
 
 You can install this module using PowerShellGet.


### PR DESCRIPTION
While trying to use the ALZ module I kept getting the error: 

command was found in the module 'ALZ', but the module could not be loaded. For more information, run 'Import-Module ALZ'. objectNotFound CouldNotAutoloadMatchingModule

and eve though i had updated to PS 7 - it kept showing as 5. I needed to set the alias so everything would work.

# Pull Request

## Issue

Issue #, if available:

## Description

Description of changes:

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
