### PR TITLE
Change `git init` logic

### DIFF
--- a/src/ALZ/Private/Test-ALZGitRepository.ps1
+++ b/src/ALZ/Private/Test-ALZGitRepository.ps1
@@ -15,8 +15,8 @@ function Test-ALZGitRepository {
     $gitInit = Read-Host "Initialize the directory $alzEnvironmentDestination as a git repository? (y/n)"
     if ($gitInit -ieq "y" -and $PSCmdlet.ShouldProcess("gitrepository", "initialize")) {
         $gitBranch = Read-Host "Enter the default branch name. (Hit enter to skip and use 'main')"
-        if($gitBranch -eq "") {
-          $gitBranch = "main"
+        if ($gitBranch -eq "") {
+            $gitBranch = "main"
         }
         git init -b $gitBranch $alzEnvironmentDestination
         return $true

--- a/src/ALZ/Private/Test-ALZGitRepository.ps1
+++ b/src/ALZ/Private/Test-ALZGitRepository.ps1
@@ -14,7 +14,7 @@ function Test-ALZGitRepository {
     }
     $gitInit = Read-Host "Initialize the directory $alzEnvironmentDestination as a git repository? (y/n)"
     if ($gitInit -ieq "y"  -and $PSCmdlet.ShouldProcess("gitrepository", "initialize")) {
-        git init $alzEnvironmentDestination
+        git init -b main $alzEnvironmentDestination
         return $true
     }
     return $false

--- a/src/ALZ/Private/Test-ALZGitRepository.ps1
+++ b/src/ALZ/Private/Test-ALZGitRepository.ps1
@@ -14,13 +14,12 @@ function Test-ALZGitRepository {
     }
     $gitInit = Read-Host "Initialize the directory $alzEnvironmentDestination as a git repository? (y/n)"
     if ($gitInit -ieq "y" -and $PSCmdlet.ShouldProcess("gitrepository", "initialize")) {
-        if ((git config --get init.defaultbranch) -eq "master") {
-            git init -b main $alzEnvironmentDestination
-            return $true
-        } else {
-            git init $alzEnvironmentDestination
-            return $true
+        $gitBranch = Read-Host "Enter the default branch name. (Hit enter to skip and use 'main')"
+        if($gitBranch -eq "") {
+          $gitBranch = "main"
         }
+        git init -b $gitBranch $alzEnvironmentDestination
+        return $true
     }
     return $false
 }

--- a/src/ALZ/Private/Test-ALZGitRepository.ps1
+++ b/src/ALZ/Private/Test-ALZGitRepository.ps1
@@ -13,9 +13,14 @@ function Test-ALZGitRepository {
         return $true
     }
     $gitInit = Read-Host "Initialize the directory $alzEnvironmentDestination as a git repository? (y/n)"
-    if ($gitInit -ieq "y"  -and $PSCmdlet.ShouldProcess("gitrepository", "initialize")) {
-        git init -b main $alzEnvironmentDestination
-        return $true
+    if ($gitInit -ieq "y" -and $PSCmdlet.ShouldProcess("gitrepository", "initialize")) {
+        if ((git config --get init.defaultbranch) -eq "master") {
+            git init -b main $alzEnvironmentDestination
+            return $true
+        } else {
+            git init $alzEnvironmentDestination
+            return $true
+        }
     }
     return $false
 }


### PR DESCRIPTION
To align with https://github.com/github/renaming we have altered the `git init` logic.

This pull request introduces a change to the `Test-ALZGitRepository` function in the `src/ALZ/Private/Test-ALZGitRepository.ps1` file. The change adds a check for the `init.defaultbranch` git configuration variable to initialize the repository with the default branch set to "main" instead of "master" if necessary.

Main change:

* [`src/ALZ/Private/Test-ALZGitRepository.ps1`](diffhunk://#diff-f812e07345936b49445b2ee7a222296b624e8ec80605dda1ef252a819ebb8d57R17-R24): Added a check for the `init.defaultbranch` git configuration variable in the `Test-ALZGitRepository` function to initialize the repository with the default branch set to "main" instead of "master" if necessary.