### PR TITLE
Change init command to ovverride client default name

### DIFF
--- a/src/ALZ/Private/Test-ALZGitRepository.ps1
+++ b/src/ALZ/Private/Test-ALZGitRepository.ps1
@@ -14,7 +14,7 @@ function Test-ALZGitRepository {
     }
     $gitInit = Read-Host "Initialize the directory $alzEnvironmentDestination as a git repository? (y/n)"
     if ($gitInit -ieq "y"  -and $PSCmdlet.ShouldProcess("gitrepository", "initialize")) {
-        git init $alzEnvironmentDestination
+        git init $alzEnvironmentDestination -b main
         return $true
     }
     return $false


### PR DESCRIPTION
# Pull Request
Git's default install uses master as the default branch name. All of the accelerator documentation references main, so in order to align to that, this change will override the client's default branch name.

## Issue

NA

## Description

1. git init now has an additional arg specified to override branch name to main.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
