### PR TITLE
Add config file specific code

### DIFF
--- a/src/ALZ/Private/Convert-HCLVariablesToUserInputConfig.ps1
+++ b/src/ALZ/Private/Convert-HCLVariablesToUserInputConfig.ps1
@@ -54,8 +54,8 @@ function Convert-HCLVariablesToUserInputConfig {
             }
 
             $inputType = "UserInput"
-            if($hasValidation -and $validationType -eq "hidden_azure_subscription_ids") {
-                $inputType = "AzureSubscriptionIds"
+            if($hasValidation -and $validationType -like "hidden_*") {
+                $inputType = "ComputedInput"
             }
 
             $sensitive = $false
@@ -89,8 +89,6 @@ function Convert-HCLVariablesToUserInputConfig {
                 }
                 $starterModuleConfigurationInstance | Add-Member -NotePropertyName "DefaultValue" -NotePropertyValue $defaultValue
             }
-
-
 
             if($hasValidation) {
                 $validator = $validators.PSObject.Properties[$validationType].Value

--- a/src/ALZ/Private/Import-ConfigurationFile.ps1
+++ b/src/ALZ/Private/Import-ConfigurationFile.ps1
@@ -1,0 +1,21 @@
+function Import-ConfigurationFileData {
+    <#
+
+    #>
+    param(
+        [Parameter(Mandatory = $false)]
+        [PSCustomObject] $starterModuleConfiguration,
+        [Parameter(Mandatory = $false)]
+        [PSCustomObject] $bootstrapConfiguration
+    )
+
+    $configurationFilePathObjects = ($starterModuleConfiguration.PsObject.Properties | Where-Object { $_.Value.Validator -eq "configuration_file_path" })
+
+    if($configurationFilePathObjects.Count -eq 0) {
+        return
+    }
+
+    $configurationFilePath = $configurationFilePathObjects[0].Value.Value
+    $bootstrapConfigurationFilePathObject = $bootstrapConfiguration.PsObject.Properties | Where-Object { $_.Value.Validator -eq "hidden_configuration_file_path" }
+    $bootstrapConfigurationFilePathObject.Value.Value = $configurationFilePath
+}

--- a/src/ALZ/Private/New-ALZEnvironmentTerraform.ps1
+++ b/src/ALZ/Private/New-ALZEnvironmentTerraform.ps1
@@ -87,8 +87,9 @@ function New-ALZEnvironmentTerraform {
         # Getting the user input for the starter module
         $starterModuleConfiguration = Request-ALZEnvironmentConfig -configurationParameters $starterModuleParameters -respectOrdering -userInputOverrides $userInputOverrides -userInputDefaultOverrides $cachedStarterModuleConfig -treatEmptyDefaultAsValid $true -autoApprove:$autoApprove.IsPresent
 
-        # Getting subscription ids
+        # Getting computed inputs
         Import-SubscriptionData -starterModuleConfiguration $starterModuleConfiguration -bootstrapConfiguration $bootstrapConfiguration
+        Import-ConfigurationFileData -starterModuleConfiguration $starterModuleConfiguration -bootstrapConfiguration $bootstrapConfiguration
 
         # Creating the tfvars files for the bootstrap and starter module
         $bootstrapTfvarsPath = Join-Path -Path $bootstrapPath -ChildPath "override.tfvars"

--- a/src/ALZ/Private/Request-ConfigurationValue.ps1
+++ b/src/ALZ/Private/Request-ConfigurationValue.ps1
@@ -58,7 +58,12 @@ function Request-ConfigurationValue {
 
         $hasNotSpecifiedValue = ($null -eq $configValue.Value -or "" -eq $configValue.Value) -and ($configValue.Value -ne $configValue.DefaultValue)
         $isDisallowedValue = $hasAllowedValues -and $allowedValues.Contains($configValue.Value) -eq $false
-        $skipValidationForEmptyDefault = $treatEmptyDefaultAsValid -and $hasDefaultValue -and $defaultValue -eq "" -and $configValue.Value -eq ""
+        $skipValidationForEmptyDefault = $treatEmptyDefaultAsValid -and $hasDefaultValue -and (($defaultValue -eq "" -and $configValue.Value -eq "") -or ($configValue.Value -eq "-"))
+
+        # Reset the value to empty if we have a default and the user entered a dash (this is to handle cached situations and provide a method to clear a value)
+        if($skipValidationForEmptyDefault -and $configValue.Value -eq "-") {
+            $configValue.Value = ""
+        }
 
         if($skipValidationForEmptyDefault) {
             $isNotValid = $false

--- a/src/ALZ/Private/Write-ConfigurationCache.ps1
+++ b/src/ALZ/Private/Write-ConfigurationCache.ps1
@@ -16,6 +16,9 @@ function Write-ConfigurationCache {
 
         $cache = [PSCustomObject]@{}
         foreach ($configurationItem in $configuration.PSObject.Properties) {
+            if($configurationItem.Value.Type -eq "ComputedInput") {
+                continue
+            }
             $cache | Add-Member -NotePropertyName $configurationItem.Name -NotePropertyValue $configurationItem.Value.Value
         }
 

--- a/src/ALZ/Private/Write-TfvarsFile.ps1
+++ b/src/ALZ/Private/Write-TfvarsFile.ps1
@@ -16,6 +16,11 @@ function Write-TfvarsFile {
 
         foreach($configurationProperty in $configuration.PSObject.Properties) {
             $configurationValueRaw = $configurationProperty.Value.Value
+
+            if($configurationProperty.Value.Validator -eq "configuration_file_path") {
+                $configurationValueRaw = [System.IO.Path]::GetFileName($configurationValueRaw)
+            }
+
             $configurationValue = "`"$($configurationValueRaw)`""
 
             if($configurationProperty.Value.DataType -eq "list(string)") {
@@ -30,6 +35,8 @@ function Write-TfvarsFile {
 
             if($configurationProperty.Value.DataType -eq "number" -or $configurationProperty.Value.DataType -eq "bool") {
                 $configurationValue = $configurationValueRaw
+            } else {
+                $configurationValue = $configurationValue.Replace("\", "\\")
             }
 
             Add-Content -Path $tfvarsFilePath -Value "$($configurationProperty.Name) = $($configurationValue)"


### PR DESCRIPTION
# Pull Request

## Issue

Issue #, if available: N/A

## Description

Description of changes:

This PR adds the ability to pass a config file path that is then included in the repository. This is to be more concise for users of the accelerator and only prompt for a config file if they are using a starter module that needs one. Also enables them to call the config file whatever name they desire.

This change has been tested and testing evidence can be found in the sister PR here: https://github.com/Azure/alz-terraform-accelerator/pull/89

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
