### PR TITLE
enhacement: add better error handling and masking for inputs

### DIFF
--- a/src/ALZ/Private/Get-ALZConfig.ps1
+++ b/src/ALZ/Private/Get-ALZConfig.ps1
@@ -13,14 +13,28 @@ function Get-ALZConfig {
 
     # Import the config and transform it to a PowerShell object
     $extension = (Get-Item -Path $configFilePath).Extension.ToLower()
+    $config = $null
     if($extension -eq ".yml" -or $extension -eq ".yaml") {
         if (!(Get-Module -ListAvailable -Name powershell-Yaml)) {
             Write-Host "Installing YAML module"
             Install-Module powershell-Yaml -Force
         }
-        $config = [PSCustomObject](Get-Content -Path $configFilePath | ConvertFrom-Yaml)
+        try {
+            $config = [PSCustomObject](Get-Content -Path $configFilePath | ConvertFrom-Yaml)
+        } catch {
+            $errorMessage = "Failed to parse YAML inputs. Please check the YAML file for errors and try again. $_"
+            Write-Error $errorMessage
+            throw $errorMessage
+        }
+
     } elseif($extension -eq ".json") {
-        $config = Get-Content -Path $configFilePath | ConvertFrom-Json
+        try {
+            $config = [PSCustomObject](Get-Content -Path $configFilePath | ConvertFrom-Json)
+        } catch {
+            $errorMessage = "Failed to parse JSON inputs. Please check the JSON file for errors and try again. $_"
+            Write-Error $errorMessage
+            throw $errorMessage
+        }
     } else {
         throw "The config file must be a json or yaml/yml file"
     }

--- a/src/ALZ/Private/Request-ConfigurationValue.ps1
+++ b/src/ALZ/Private/Request-ConfigurationValue.ps1
@@ -37,6 +37,9 @@ function Request-ConfigurationValue {
         Write-InformationColored "$($configName) " -ForegroundColor Yellow -NoNewline -InformationAction Continue
         if ($hasDefaultValue) {
             $displayDefaultValue = $defaultValue -eq "" ? "''" : $defaultValue
+            if($configValue.Sensitive -and $defaultValue -ne "") {
+                $displayDefaultValue = "<sensitive>"
+            }
             Write-InformationColored "(default: ${displayDefaultValue}): " -ForegroundColor Yellow -NoNewline -InformationAction Continue
         } else {
             Write-InformationColored ": " -NoNewline -InformationAction Continue


### PR DESCRIPTION
# Pull Request

## Issue

Issue #, if available: N/A

## Description

Description of changes:

- Reported by VBD team that the error message is not clear when invalid yaml or json are passed.

- The PAT is not masked when using cached values on a second run.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
