### PR TITLE
Updates to support telemetry and better prompts

### DIFF
--- a/src/ALZ/Private/Config-Helpers/Request-SpecialInput.ps1
+++ b/src/ALZ/Private/Config-Helpers/Request-SpecialInput.ps1
@@ -18,6 +18,7 @@ function Request-SpecialInput {
 
         $result = ""
         $options = @()
+        $aliasOptions = @()
         $typeDescription = ""
 
         if($type -eq "iac") {
@@ -33,6 +34,9 @@ function Request-SpecialInput {
             } else {
                 foreach ($bootstrapModule in $bootstrapModules.PsObject.Properties) {
                     $options += @{ key = $bootstrapModule.Name; name = $bootstrapModule.Value.short_name; description = $bootstrapModule.Value.description }
+                    foreach($alias in $bootstrapModule.Value.aliases) {
+                        $aliasOptions += @{ key = $alias; name = $bootstrapModule.Value.short_name; description = $bootstrapModule.Value.description }
+                    }
                 }
             }
             $typeDescription = "bootstrap module"
@@ -53,7 +57,7 @@ function Request-SpecialInput {
             $userInputOverride = $userInputOverrides.PSObject.Properties | Where-Object { $_.Name -eq $type }
             if($null -ne $userInputOverride) {
                 $result = $userInputOverride.Value
-                if($options.key -notcontains $result) {
+                if($options.key -notcontains $result -and $aliasOptions.key -notcontains $result) {
                     Write-InformationColored "The $typeDescription '$result' that you have selected does not exist. Please try again with a valid $typeDescription..." -ForegroundColor Red -InformationAction Continue
                     throw "The $typeDescription '$result' that you have selected does not exist. Please try again with a valid $typeDescription..."
                 }

--- a/src/ALZ/Private/Config-Helpers/Request-SpecialInput.ps1
+++ b/src/ALZ/Private/Config-Helpers/Request-SpecialInput.ps1
@@ -31,6 +31,8 @@ function Request-SpecialInput {
             if($bootstrapModules.PsObject.Properties.Name.Count -eq 0) {
                 $options += @{ key = "azuredevops"; name = "Azure DevOps"; description = "Azure DevOps" }
                 $options += @{ key = "github"; name = "GitHub"; description = "GitHub" }
+                $aliasOptions += @{ key = "alz_azuredevops"; name = "Azure DevOps"; description = "Azure DevOps" }
+                $aliasOptions += @{ key = "alz_github"; name = "GitHub"; description = "GitHub" }
             } else {
                 foreach ($bootstrapModule in $bootstrapModules.PsObject.Properties) {
                     $options += @{ key = $bootstrapModule.Name; name = $bootstrapModule.Value.short_name; description = $bootstrapModule.Value.description }

--- a/src/ALZ/Private/Config-Helpers/Request-SpecialInput.ps1
+++ b/src/ALZ/Private/Config-Helpers/Request-SpecialInput.ps1
@@ -5,7 +5,7 @@ function Request-SpecialInput {
         [string] $type,
 
         [Parameter(Mandatory = $false)]
-        [string] $starterPath,
+        [PSCustomObject] $starterConfig,
 
         [Parameter(Mandatory = $false)]
         [PSCustomObject] $bootstrapModules,
@@ -17,82 +17,72 @@ function Request-SpecialInput {
     if ($PSCmdlet.ShouldProcess("ALZ-Terraform module configuration", "modify")) {
 
         $result = ""
+        $options = @()
+        $typeDescription = ""
+
+        if($type -eq "iac") {
+            $options += @{ key = "bicep"; name = "Bicep"; description = "Bicep" }
+            $options += @{ key = "terraform"; name = "Terraform"; description = "Terraform" }
+            $typeDescription = "Infrastructure as Code (IaC) language"
+        }
+
+        if($type -eq "bootstrap") {
+            if($bootstrapModules.PsObject.Properties.Name.Count -eq 0) {
+                $options += @{ key = "azuredevops"; name = "Azure DevOps"; description = "Azure DevOps" }
+                $options += @{ key = "github"; name = "GitHub"; description = "GitHub" }
+            } else {
+                foreach ($bootstrapModule in $bootstrapModules.PsObject.Properties) {
+                    $options += @{ key = $bootstrapModule.Name; name = $bootstrapModule.Value.short_name; description = $bootstrapModule.Value.description }
+                }
+            }
+            $typeDescription = "bootstrap module"
+        }
+
+        if($type -eq "starter") {
+            foreach($starter in $starterConfig.starter_modules.PsObject.Properties) {
+                if($starter.Name -eq $starterPipelineFolder) {
+                    continue
+                }
+
+                $options += @{ key = $starter.Name; name = $starter.Value.short_name; description = $starter.Value.description }
+            }
+            $typeDescription = "starter module"
+        }
 
         if($null -ne $userInputOverrides) {
             $userInputOverride = $userInputOverrides.PSObject.Properties | Where-Object { $_.Name -eq $type }
             if($null -ne $userInputOverride) {
                 $result = $userInputOverride.Value
+                if($options.key -notcontains $result) {
+                    Write-InformationColored "The $typeDescription '$result' that you have selected does not exist. Please try again with a valid $typeDescription..." -ForegroundColor Red -InformationAction Continue
+                    throw "The $typeDescription '$result' that you have selected does not exist. Please try again with a valid $typeDescription..."
+                }
                 return $result
             }
         }
 
-        $gotValidInput = $false
+        # Add the options to the choices array
+        $choices = @()
+        $usedLetters = @()
+        foreach($option in $options) {
+            $letterIndex = 0
 
-        while(!$gotValidInput) {
-            if($type -eq "starter") {
-
-                $starterFolders = Get-ChildItem -Path $starterPath -Directory
-                Write-InformationColored "Please select the starter module you would like to use, you can enter one of the following keys:" -ForegroundColor Yellow -InformationAction Continue
-
-                $starterOptions = @()
-                foreach($starterFolder in $starterFolders) {
-                    if($starterFolder.Name -eq $starterPipelineFolder) {
-                        continue
-                    }
-
-                    Write-InformationColored "- $($starterFolder.Name)" -ForegroundColor Yellow -InformationAction Continue
-                    $starterOptions += $starterFolder.Name
-                }
-
-                Write-InformationColored ": " -ForegroundColor Yellow -NoNewline -InformationAction Continue
-                $result = Read-Host
-
-                if($result -notin $starterOptions) {
-                    Write-InformationColored "The starter '$result' that you have selected does not exist. Please try again with a valid starter..." -ForegroundColor Red -InformationAction Continue
-                } else {
-                    $gotValidInput = $true
-                }
+            Write-Verbose "Checking for used letters in '$($option.name)'. Used letters: $usedLetters"
+            while($usedLetters -contains $option.name[$letterIndex].ToString().ToLower()) {
+                $letterIndex++
             }
 
-            if($type -eq "iac") {
-                Write-InformationColored "Please select the IAC you would like to use, you can enter one of 'bicep or 'terraform': " -ForegroundColor Yellow -NoNewline -InformationAction Continue
-                $result = Read-Host
-
-                $validIac = @("bicep", "terraform")
-                if($result -notin $validIac) {
-                    Write-InformationColored "The IAC '$result' that you have selected does not exist. Please try again with a valid IAC..." -ForegroundColor Red -InformationAction Continue
-
-                } else {
-                    $gotValidInput = $true
-                }
-            }
-
-            if($type -eq "bootstrap") {
-                Write-InformationColored "Please select the bootstrap module you would like to use, you can enter one of the following keys:" -ForegroundColor Yellow -InformationAction Continue
-
-                $bootstrapOptions = @()
-                if($bootstrapModules.PsObject.Properties.Name.Count -eq 0) {
-                    $bootstrapOptions += "azuredevops"
-                    Write-InformationColored "- azuredevops" -ForegroundColor Yellow -InformationAction Continue
-                    $bootstrapOptions += "github"
-                    Write-InformationColored "- github" -ForegroundColor Yellow -InformationAction Continue
-                } else {
-                    foreach ($bootstrapModule in $bootstrapModules.PsObject.Properties) {
-                        Write-InformationColored "- $($bootstrapModule.Name) ($($bootstrapModule.Value.description))" -ForegroundColor Yellow -InformationAction Continue
-                        $bootstrapOptions += $bootstrapModule.Name
-                    }
-                }
-
-                Write-InformationColored ": " -ForegroundColor Yellow -NoNewline -InformationAction Continue
-                $result = Read-Host
-
-                if($result -notin $bootstrapOptions) {
-                    Write-InformationColored "The starter '$result' that you have selected does not exist. Please try again with a valid starter..." -ForegroundColor Red -InformationAction Continue
-                } else {
-                    $gotValidInput = $true
-                }
-            }
+            $usedLetters += $option.name[$letterIndex].ToString().ToLower()
+            $option.name = $option.name.Insert($letterIndex, "&")
+            $choices += New-Object System.Management.Automation.Host.ChoiceDescription $option.name, $option.description
         }
+
+        $message = "Please select the $typeDescription you would like to use."
+        $title = "Choose $typeDescription"
+        $resultIndex = $host.ui.PromptForChoice($title, $message, $choices, 0)
+        $result = $options[$resultIndex].key
+
+        Write-InformationColored "You selected '$result'. Continuing with deployment..." -ForegroundColor Green -InformationAction Continue
 
         return $result
     }

--- a/src/ALZ/Private/Deploy-Accelerator-Helpers/Get-BootstrapAndStarterConfig.ps1
+++ b/src/ALZ/Private/Deploy-Accelerator-Helpers/Get-BootstrapAndStarterConfig.ps1
@@ -20,7 +20,7 @@ function Get-BootstrapAndStarterConfig {
         $starterModuleSourceFolder = ""
         $starterReleaseTag = ""
         $starterPipelineFolder = ""
-        $starterReleaseArtefactName = ""
+        $starterReleaseArtifactName = ""
         $starterConfigFilePath = ""
 
         $bootstrapDetails = $null
@@ -63,10 +63,10 @@ function Get-BootstrapAndStarterConfig {
             }
 
             $starterModuleUrl = $starterModuleDetails.Value.$iac.url
-            $starterModuleSourceFolder = $starterModuleDetails.Value.$iac.release_artefact_root_path
-            $starterPipelineFolder = $starterModuleDetails.Value.$iac.release_artefact_ci_cd_path
-            $starterReleaseArtefactName = $starterModuleDetails.Value.$iac.release_artefact_name
-            $starterConfigFilePath = $starterModuleDetails.Value.$iac.release_artefact_config_file
+            $starterModuleSourceFolder = $starterModuleDetails.Value.$iac.release_artifact_root_path
+            $starterPipelineFolder = $starterModuleDetails.Value.$iac.release_artifact_ci_cd_path
+            $starterReleaseArtifactName = $starterModuleDetails.Value.$iac.release_artifact_name
+            $starterConfigFilePath = $starterModuleDetails.Value.$iac.release_artifact_config_file
         }
 
         # Get the bootstrap interface user input config
@@ -81,7 +81,7 @@ function Get-BootstrapAndStarterConfig {
             starterModuleSourceFolder  = $starterModuleSourceFolder
             starterReleaseTag          = $starterReleaseTag
             starterPipelineFolder      = $starterPipelineFolder
-            starterReleaseArtefactName = $starterReleaseArtefactName
+            starterReleaseArtifactName = $starterReleaseArtifactName
             starterConfigFilePath      = $starterConfigFilePath
             validationConfig           = $validationConfig
             inputConfig                = $inputConfig

--- a/src/ALZ/Private/Deploy-Accelerator-Helpers/Get-BootstrapAndStarterConfig.ps1
+++ b/src/ALZ/Private/Deploy-Accelerator-Helpers/Get-BootstrapAndStarterConfig.ps1
@@ -20,6 +20,8 @@ function Get-BootstrapAndStarterConfig {
         $starterModuleSourceFolder = ""
         $starterReleaseTag = ""
         $starterPipelineFolder = ""
+        $starterReleaseArtefactName = ""
+        $starterConfigFilePath = ""
 
         $bootstrapDetails = $null
         $validationConfig = $null
@@ -61,8 +63,10 @@ function Get-BootstrapAndStarterConfig {
             }
 
             $starterModuleUrl = $starterModuleDetails.Value.$iac.url
-            $starterModuleSourceFolder = $starterModuleDetails.Value.$iac.module_path
-            $starterPipelineFolder = $starterModuleDetails.Value.$iac.pipeline_folder
+            $starterModuleSourceFolder = $starterModuleDetails.Value.$iac.release_artefact_root_path
+            $starterPipelineFolder = $starterModuleDetails.Value.$iac.release_artefact_ci_cd_path
+            $starterReleaseArtefactName = $starterModuleDetails.Value.$iac.release_artefact_name
+            $starterConfigFilePath = $starterModuleDetails.Value.$iac.release_artefact_config_file
         }
 
         # Get the bootstrap interface user input config
@@ -71,14 +75,16 @@ function Get-BootstrapAndStarterConfig {
         $inputConfig = Get-ALZConfig -configFilePath $inputConfigFilePath
 
         return @{
-            bootstrapDetails          = $bootstrapDetails
-            hasStarterModule          = $hasStarterModule
-            starterModuleUrl          = $starterModuleUrl
-            starterModuleSourceFolder = $starterModuleSourceFolder
-            starterReleaseTag         = $starterReleaseTag
-            starterPipelineFolder     = $starterPipelineFolder
-            validationConfig          = $validationConfig
-            inputConfig               = $inputConfig
+            bootstrapDetails           = $bootstrapDetails
+            hasStarterModule           = $hasStarterModule
+            starterModuleUrl           = $starterModuleUrl
+            starterModuleSourceFolder  = $starterModuleSourceFolder
+            starterReleaseTag          = $starterReleaseTag
+            starterPipelineFolder      = $starterPipelineFolder
+            starterReleaseArtefactName = $starterReleaseArtefactName
+            starterConfigFilePath      = $starterConfigFilePath
+            validationConfig           = $validationConfig
+            inputConfig                = $inputConfig
         }
     }
 }

--- a/src/ALZ/Private/Deploy-Accelerator-Helpers/Get-StarterConfig.ps1
+++ b/src/ALZ/Private/Deploy-Accelerator-Helpers/Get-StarterConfig.ps1
@@ -1,0 +1,19 @@
+
+function Get-StarterConfig {
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$starterPath,
+        [Parameter(Mandatory = $false)]
+        [string]$starterConfigPath
+    )
+
+    if ($PSCmdlet.ShouldProcess("Get Configuration for Bootstrap and Starter", "modify")) {
+        # Get the bootstap configuration
+        $starterConfigFullPath = Join-Path $starterPath $starterConfigPath
+        Write-Verbose "Starter config path $starterConfigFullPath"
+        $starterConfig = Get-ALZConfig -configFilePath $starterConfigFullPath
+
+        return $starterConfig
+    }
+}

--- a/src/ALZ/Private/Deploy-Accelerator-Helpers/New-Bootstrap.ps1
+++ b/src/ALZ/Private/Deploy-Accelerator-Helpers/New-Bootstrap.ps1
@@ -26,6 +26,9 @@ function New-Bootstrap {
         [string] $starterTargetPath,
 
         [Parameter(Mandatory = $false)]
+        [PSCustomObject] $starterConfig = $null,
+
+        [Parameter(Mandatory = $false)]
         [string] $bootstrapRelease,
 
         [Parameter(Mandatory = $false)]
@@ -83,8 +86,11 @@ function New-Bootstrap {
         $pipelineModulePath = ""
 
         if($hasStarter) {
-            $starter = Request-SpecialInput -type "starter" -starterPath $starterPath -userInputOverrides $userInputOverrides
-            $starterModulePath = Resolve-Path (Join-Path -Path $starterPath -ChildPath $starter)
+            $starter = Request-SpecialInput -type "starter" -starterConfig $starterConfig -userInputOverrides $userInputOverrides
+
+            Write-Verbose "Selected Starter: $starter"
+
+            $starterModulePath = Resolve-Path (Join-Path -Path $starterPath -ChildPath $starterConfig.starter_modules.$starter.location)
             $pipelineModulePath = Resolve-Path (Join-Path -Path $starterPath -ChildPath $starterPipelineFolder)
 
             Write-Verbose "Starter Module Path: $starterModulePath"

--- a/src/ALZ/Private/Deploy-Accelerator-Helpers/New-FolderStructure.ps1
+++ b/src/ALZ/Private/Deploy-Accelerator-Helpers/New-FolderStructure.ps1
@@ -11,7 +11,7 @@ function New-FolderStructure {
         [string] $release = "latest",
 
         [Parameter(Mandatory = $false)]
-        [string] $releaseArtefactName = "",
+        [string] $releaseArtifactName = "",
 
         [Parameter(Mandatory = $true)]
         [string] $targetFolder,
@@ -46,7 +46,7 @@ function New-FolderStructure {
             }
 
         } else {
-            $releaseTag = Get-GithubRelease -githubRepoUrl $url -targetDirectory $targetDirectory -moduleSourceFolder $sourceFolder -moduleTargetFolder $targetFolder -release $release -releaseArtefactName $releaseArtefactName
+            $releaseTag = Get-GithubRelease -githubRepoUrl $url -targetDirectory $targetDirectory -moduleSourceFolder $sourceFolder -moduleTargetFolder $targetFolder -release $release -releaseArtifactName $releaseArtifactName
             $path = Join-Path $targetDirectory $targetFolder $releaseTag
         }
 

--- a/src/ALZ/Private/Deploy-Accelerator-Helpers/New-FolderStructure.ps1
+++ b/src/ALZ/Private/Deploy-Accelerator-Helpers/New-FolderStructure.ps1
@@ -10,6 +10,9 @@ function New-FolderStructure {
         [Parameter(Mandatory = $false)]
         [string] $release = "latest",
 
+        [Parameter(Mandatory = $false)]
+        [string] $releaseArtefactName = "",
+
         [Parameter(Mandatory = $true)]
         [string] $targetFolder,
 
@@ -43,7 +46,7 @@ function New-FolderStructure {
             }
 
         } else {
-            $releaseTag = Get-GithubRelease -githubRepoUrl $url -targetDirectory $targetDirectory -moduleSourceFolder $sourceFolder -moduleTargetFolder $targetFolder -release $release
+            $releaseTag = Get-GithubRelease -githubRepoUrl $url -targetDirectory $targetDirectory -moduleSourceFolder $sourceFolder -moduleTargetFolder $targetFolder -release $release -releaseArtefactName $releaseArtefactName
             $path = Join-Path $targetDirectory $targetFolder $releaseTag
         }
 

--- a/src/ALZ/Private/Deploy-Accelerator-Helpers/New-ModuleSetup.ps1
+++ b/src/ALZ/Private/Deploy-Accelerator-Helpers/New-ModuleSetup.ps1
@@ -13,6 +13,8 @@ function New-ModuleSetup {
         [Parameter(Mandatory = $false)]
         [string]$release,
         [Parameter(Mandatory = $false)]
+        [string]$releaseArtefactName = "",
+        [Parameter(Mandatory = $false)]
         [string]$moduleOverrideFolderPath,
         [Parameter(Mandatory = $false)]
         [bool]$skipInternetChecks
@@ -28,6 +30,7 @@ function New-ModuleSetup {
                 -targetDirectory $targetDirectory `
                 -url $url `
                 -release $release `
+                -releaseArtefactName $releaseArtefactName `
                 -targetFolder $targetFolder `
                 -sourceFolder $sourceFolder `
                 -overrideSourceDirectoryPath $moduleOverrideFolderPath

--- a/src/ALZ/Private/Deploy-Accelerator-Helpers/New-ModuleSetup.ps1
+++ b/src/ALZ/Private/Deploy-Accelerator-Helpers/New-ModuleSetup.ps1
@@ -13,7 +13,7 @@ function New-ModuleSetup {
         [Parameter(Mandatory = $false)]
         [string]$release,
         [Parameter(Mandatory = $false)]
-        [string]$releaseArtefactName = "",
+        [string]$releaseArtifactName = "",
         [Parameter(Mandatory = $false)]
         [string]$moduleOverrideFolderPath,
         [Parameter(Mandatory = $false)]
@@ -30,7 +30,7 @@ function New-ModuleSetup {
                 -targetDirectory $targetDirectory `
                 -url $url `
                 -release $release `
-                -releaseArtefactName $releaseArtefactName `
+                -releaseArtifactName $releaseArtifactName `
                 -targetFolder $targetFolder `
                 -sourceFolder $sourceFolder `
                 -overrideSourceDirectoryPath $moduleOverrideFolderPath

--- a/src/ALZ/Private/Shared/Get-GithubRelease.ps1
+++ b/src/ALZ/Private/Shared/Get-GithubRelease.ps1
@@ -44,8 +44,8 @@ function Get-GithubRelease {
         [Parameter(Mandatory = $true, HelpMessage = "The target directory location of the modules.")]
         $moduleTargetFolder,
 
-        [Parameter(Mandatory = $false, HelpMessage = "The name of the release artefact in the target release. Defaults to standard release zip.")]
-        $releaseArtefactName = ""
+        [Parameter(Mandatory = $false, HelpMessage = "The name of the release artifact in the target release. Defaults to standard release zip.")]
+        $releaseArtifactName = ""
     )
 
     $parentDirectory = $targetDirectory
@@ -114,16 +114,16 @@ function Get-GithubRelease {
         New-Item -ItemType Directory -Path "$targetVersionPath/tmp" | Out-String | Write-Verbose
         $targetPathForZip = "$targetVersionPath/tmp/$releaseTag.zip"
 
-        # Get the artefact url
-        if($releaseArtefactName -ne "") {
-            $releaseArtefactUrl = $releaseData.assets | Where-Object { $_.name -eq $releaseArtefactName } | Select-Object -ExpandProperty browser_download_url
+        # Get the artifact url
+        if($releaseArtifactName -ne "") {
+            $releaseArtifactUrl = $releaseData.assets | Where-Object { $_.name -eq $releaseArtifactName } | Select-Object -ExpandProperty browser_download_url
         } else {
-            $releaseArtefactUrl = $releaseData.zipball_url
+            $releaseArtifactUrl = $releaseData.zipball_url
         }
 
-        Write-Verbose "===> Downloading the release artefact $releaseArtefactUrl from the GitHub repository $repoOrgPlusRepo"
+        Write-Verbose "===> Downloading the release artifact $releaseArtifactUrl from the GitHub repository $repoOrgPlusRepo"
 
-        Invoke-WebRequest -Uri $releaseArtefactUrl -OutFile $targetPathForZip -RetryIntervalSec 3 -MaximumRetryCount 100 | Out-String | Write-Verbose
+        Invoke-WebRequest -Uri $releaseArtifactUrl -OutFile $targetPathForZip -RetryIntervalSec 3 -MaximumRetryCount 100 | Out-String | Write-Verbose
 
         if(!(Test-Path $targetPathForZip)) {
             Write-InformationColored "Failed to download the release $releaseTag from the GitHub repository $repoOrgPlusRepo" -ForegroundColor Red -InformationAction Continue
@@ -135,7 +135,7 @@ function Get-GithubRelease {
         Expand-Archive -Path $targetPathForZip -DestinationPath $targetPathForExtractedZip | Out-String | Write-Verbose
 
         $extractedSubFolder = $targetPathForExtractedZip
-        if($releaseArtefactName -eq "") {
+        if($releaseArtifactName -eq "") {
             $extractedSubFolder = (Get-ChildItem -Path $targetPathForExtractedZip -Directory).FullName
         }
 

--- a/src/ALZ/Public/New-ALZEnvironment.ps1
+++ b/src/ALZ/Public/New-ALZEnvironment.ps1
@@ -71,6 +71,10 @@ function New-ALZEnvironment {
         [string]
         $bootstrapModuleUrl = "https://github.com/Azure/accelerator-bootstrap-modules",
 
+        [Parameter(Mandatory = $false, HelpMessage = "The bootstrap modules release artefact name.")]
+        [string]
+        $bootstrapModuleReleaseArtefactName = "bootstrap_modules.zip",
+
         [Parameter(Mandatory = $false, HelpMessage = "The bootstrap config file path within the bootstrap module. This can be overridden for custom modules.")]
         [string]
         $bootstrapConfigPath = ".config/ALZ-Powershell.config.json",
@@ -155,6 +159,7 @@ function New-ALZEnvironment {
                 -sourceFolder $bootstrapSourceFolder `
                 -url $bootstrapModuleUrl `
                 -release $bootstrapRelease `
+                -releaseArtefactName $bootstrapModuleReleaseArtefactName `
                 -moduleOverrideFolderPath $bootstrapModuleOverrideFolderPath `
                 -skipInternetChecks $skipInternetChecks
 
@@ -179,6 +184,8 @@ function New-ALZEnvironment {
         $starterModuleSourceFolder = "."
         $starterReleaseTag = "local"
         $starterPipelineFolder = "local"
+        $starterReleaseArtefactName = ""
+        $starterConfigFilePath = ""
 
         $bootstrapDetails = $null
         $validationConfig = $null
@@ -198,6 +205,8 @@ function New-ALZEnvironment {
             $starterModuleSourceFolder = $bootstrapAndStarterConfig.starterModuleSourceFolder
             $starterReleaseTag = $bootstrapAndStarterConfig.starterReleaseTag
             $starterPipelineFolder = $bootstrapAndStarterConfig.starterPipelineFolder
+            $starterReleaseArtefactName = $bootstrapAndStarterConfig.starterReleaseArtefactName
+            $starterConfigFilePath = $bootstrapAndStarterConfig.starterConfigFilePath
             $validationConfig = $bootstrapAndStarterConfig.validationConfig
             $inputConfig = $bootstrapAndStarterConfig.inputConfig
         } else {
@@ -209,6 +218,7 @@ function New-ALZEnvironment {
         # Download the starter modules
         $starterReleaseTag = ""
         $starterPath = ""
+        $starterConfig = $null
 
         if(($hasStarterModule -or $isLegacyBicep)) {
             Write-InformationColored "Checking and Downloading the starter module..." -ForegroundColor Green -NewLineBefore -InformationAction Continue
@@ -219,11 +229,15 @@ function New-ALZEnvironment {
                 -sourceFolder $starterModuleSourceFolder `
                 -url $starterModuleUrl `
                 -release $starterRelease `
+                -releaseArtefactName $starterReleaseArtefactName `
                 -moduleOverrideFolderPath $starterModuleOverrideFolderPath `
                 -skipInternetChecks $skipInternetChecks
 
             $starterReleaseTag = $versionAndPath.releaseTag
             $starterPath = $versionAndPath.path
+            if($starterConfigFilePath -ne "") {
+                $starterConfig = Get-StarterConfig -starterPath $starterPath -starterConfigPath $starterConfigFilePath
+            }
         }
 
         # Run the bicep parameter setup if the iac is Bicep
@@ -262,6 +276,7 @@ function New-ALZEnvironment {
                 -starterTargetPath $starterTargetPath `
                 -starterPipelineFolder $starterPipelineFolder `
                 -starterRelease $starterReleaseTag `
+                -starterConfig $starterConfig `
                 -userInputOverrides $userInputOverrides `
                 -autoApprove:$autoApprove.IsPresent `
                 -destroy:$destroy.IsPresent

--- a/src/ALZ/Public/New-ALZEnvironment.ps1
+++ b/src/ALZ/Public/New-ALZEnvironment.ps1
@@ -5,7 +5,7 @@ function New-ALZEnvironment {
     .DESCRIPTION
     This function is used to deploy accelerators consisting or bootstrap and optionally starter modules. The accelerators are designed to simplify and speed up configuration of common Microsoft patterns, such as CI / CD for Azure Landing Zones.
     .PARAMETER output
-    The target directory for the accelerator artefacts. Depending on the choice and type of accelerlerator, this may be an intermediate stage or the final result of the accelerator.
+    The target directory for the accelerator artifacts. Depending on the choice and type of accelerlerator, this may be an intermediate stage or the final result of the accelerator.
     .PARAMETER iac
     The type of infrastructure as code that the accelerator implements. For example bicep or terraform.
     .PARAMETER bootstrap
@@ -71,9 +71,9 @@ function New-ALZEnvironment {
         [string]
         $bootstrapModuleUrl = "https://github.com/Azure/accelerator-bootstrap-modules",
 
-        [Parameter(Mandatory = $false, HelpMessage = "The bootstrap modules release artefact name.")]
+        [Parameter(Mandatory = $false, HelpMessage = "The bootstrap modules release artifact name.")]
         [string]
-        $bootstrapModuleReleaseArtefactName = "bootstrap_modules.zip",
+        $bootstrapModuleReleaseArtifactName = "bootstrap_modules.zip",
 
         [Parameter(Mandatory = $false, HelpMessage = "The bootstrap config file path within the bootstrap module. This can be overridden for custom modules.")]
         [string]
@@ -159,7 +159,7 @@ function New-ALZEnvironment {
                 -sourceFolder $bootstrapSourceFolder `
                 -url $bootstrapModuleUrl `
                 -release $bootstrapRelease `
-                -releaseArtefactName $bootstrapModuleReleaseArtefactName `
+                -releaseArtifactName $bootstrapModuleReleaseArtifactName `
                 -moduleOverrideFolderPath $bootstrapModuleOverrideFolderPath `
                 -skipInternetChecks $skipInternetChecks
 
@@ -184,7 +184,7 @@ function New-ALZEnvironment {
         $starterModuleSourceFolder = "."
         $starterReleaseTag = "local"
         $starterPipelineFolder = "local"
-        $starterReleaseArtefactName = ""
+        $starterReleaseArtifactName = ""
         $starterConfigFilePath = ""
 
         $bootstrapDetails = $null
@@ -205,7 +205,7 @@ function New-ALZEnvironment {
             $starterModuleSourceFolder = $bootstrapAndStarterConfig.starterModuleSourceFolder
             $starterReleaseTag = $bootstrapAndStarterConfig.starterReleaseTag
             $starterPipelineFolder = $bootstrapAndStarterConfig.starterPipelineFolder
-            $starterReleaseArtefactName = $bootstrapAndStarterConfig.starterReleaseArtefactName
+            $starterReleaseArtifactName = $bootstrapAndStarterConfig.starterReleaseArtifactName
             $starterConfigFilePath = $bootstrapAndStarterConfig.starterConfigFilePath
             $validationConfig = $bootstrapAndStarterConfig.validationConfig
             $inputConfig = $bootstrapAndStarterConfig.inputConfig
@@ -229,7 +229,7 @@ function New-ALZEnvironment {
                 -sourceFolder $starterModuleSourceFolder `
                 -url $starterModuleUrl `
                 -release $starterRelease `
-                -releaseArtefactName $starterReleaseArtefactName `
+                -releaseArtifactName $starterReleaseArtifactName `
                 -moduleOverrideFolderPath $starterModuleOverrideFolderPath `
                 -skipInternetChecks $skipInternetChecks
 


### PR DESCRIPTION
# Pull Request

## Issue

#114 

## Description

This PR makes no significant functional changes other than improving the prompts users see for IaC, bootstrao and starter.

The primary update is to pull the bootstrap and starter from named artefacts. By doing this we can get some usage telemetry from the GitHub API.

Note that changes have been made to the starter and bootstrap repos for Terraform to accommodate this, but all those changes are backwards compatible and already released. They are ready to go with these changes now.

## Testing

- E2E tests have be run for this branch here: https://github.com/Azure/accelerator-bootstrap-modules/actions/runs/9414281487
- Manual testing of Terraform and Bicep happy paths has been completed for prompt testing.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
