### PR TITLE
Remove redundant pipeline variable

### DIFF
--- a/src/ALZ/Private/Deploy-Accelerator-Helpers/Get-BootstrapAndStarterConfig.ps1
+++ b/src/ALZ/Private/Deploy-Accelerator-Helpers/Get-BootstrapAndStarterConfig.ps1
@@ -19,7 +19,6 @@ function Get-BootstrapAndStarterConfig {
         $starterModuleUrl = ""
         $starterModuleSourceFolder = ""
         $starterReleaseTag = ""
-        $starterPipelineFolder = ""
         $starterReleaseArtifactName = ""
         $starterConfigFilePath = ""
 
@@ -64,7 +63,6 @@ function Get-BootstrapAndStarterConfig {
 
             $starterModuleUrl = $starterModuleDetails.Value.$iac.url
             $starterModuleSourceFolder = $starterModuleDetails.Value.$iac.release_artifact_root_path
-            $starterPipelineFolder = $starterModuleDetails.Value.$iac.release_artifact_ci_cd_path
             $starterReleaseArtifactName = $starterModuleDetails.Value.$iac.release_artifact_name
             $starterConfigFilePath = $starterModuleDetails.Value.$iac.release_artifact_config_file
         }
@@ -80,7 +78,6 @@ function Get-BootstrapAndStarterConfig {
             starterModuleUrl           = $starterModuleUrl
             starterModuleSourceFolder  = $starterModuleSourceFolder
             starterReleaseTag          = $starterReleaseTag
-            starterPipelineFolder      = $starterPipelineFolder
             starterReleaseArtifactName = $starterReleaseArtifactName
             starterConfigFilePath      = $starterConfigFilePath
             validationConfig           = $validationConfig

--- a/src/ALZ/Private/Deploy-Accelerator-Helpers/New-Bootstrap.ps1
+++ b/src/ALZ/Private/Deploy-Accelerator-Helpers/New-Bootstrap.ps1
@@ -168,8 +168,8 @@ function New-Bootstrap {
 
         # Set computed interface inputs
         $computedInputMapping = @{
-            "iac_type"             = $iac
-            "module_folder_path"   = $starterModulePath
+            "iac_type"           = $iac
+            "module_folder_path" = $starterModulePath
         }
 
         foreach($inputConfigItem in $inputConfig.inputs.PSObject.Properties) {

--- a/src/ALZ/Private/Deploy-Accelerator-Helpers/New-Bootstrap.ps1
+++ b/src/ALZ/Private/Deploy-Accelerator-Helpers/New-Bootstrap.ps1
@@ -35,9 +35,6 @@ function New-Bootstrap {
         [string] $starterRelease,
 
         [Parameter(Mandatory = $false)]
-        [string] $starterPipelineFolder,
-
-        [Parameter(Mandatory = $false)]
         [switch] $autoApprove,
 
         [Parameter(Mandatory = $false)]
@@ -83,7 +80,6 @@ function New-Bootstrap {
         # Get starter module
         $starter = ""
         $starterModulePath = ""
-        $pipelineModulePath = ""
 
         if($hasStarter) {
             $starter = Request-SpecialInput -type "starter" -starterConfig $starterConfig -userInputOverrides $userInputOverrides
@@ -91,10 +87,8 @@ function New-Bootstrap {
             Write-Verbose "Selected Starter: $starter"
 
             $starterModulePath = Resolve-Path (Join-Path -Path $starterPath -ChildPath $starterConfig.starter_modules.$starter.location)
-            $pipelineModulePath = Resolve-Path (Join-Path -Path $starterPath -ChildPath $starterPipelineFolder)
 
             Write-Verbose "Starter Module Path: $starterModulePath"
-            Write-Verbose "Pipeline Module Path: $pipelineModulePath"
         }
 
         # Getting the configuration for the interface user input
@@ -176,7 +170,6 @@ function New-Bootstrap {
         $computedInputMapping = @{
             "iac_type"             = $iac
             "module_folder_path"   = $starterModulePath
-            "pipeline_folder_path" = $pipelineModulePath
         }
 
         foreach($inputConfigItem in $inputConfig.inputs.PSObject.Properties) {
@@ -213,8 +206,6 @@ function New-Bootstrap {
             -treatEmptyDefaultAsValid $true `
             -autoApprove:$autoApprove.IsPresent `
             -computedInputs $bootstrapComputed
-
-
 
         # Getting the user input for the starter module
         Write-InformationColored "The following inputs are specific to the '$starter' starter module that you selected:" -ForegroundColor Green -NewLineBefore -InformationAction Continue

--- a/src/ALZ/Public/New-ALZEnvironment.ps1
+++ b/src/ALZ/Public/New-ALZEnvironment.ps1
@@ -183,7 +183,6 @@ function New-ALZEnvironment {
         $starterModuleUrl = $bicepLegacyUrl
         $starterModuleSourceFolder = "."
         $starterReleaseTag = "local"
-        $starterPipelineFolder = "local"
         $starterReleaseArtifactName = ""
         $starterConfigFilePath = ""
 
@@ -204,7 +203,6 @@ function New-ALZEnvironment {
             $starterModuleUrl = $bootstrapAndStarterConfig.starterModuleUrl
             $starterModuleSourceFolder = $bootstrapAndStarterConfig.starterModuleSourceFolder
             $starterReleaseTag = $bootstrapAndStarterConfig.starterReleaseTag
-            $starterPipelineFolder = $bootstrapAndStarterConfig.starterPipelineFolder
             $starterReleaseArtifactName = $bootstrapAndStarterConfig.starterReleaseArtifactName
             $starterConfigFilePath = $bootstrapAndStarterConfig.starterConfigFilePath
             $validationConfig = $bootstrapAndStarterConfig.validationConfig
@@ -274,7 +272,6 @@ function New-ALZEnvironment {
                 -bootstrapRelease $bootstrapReleaseTag `
                 -hasStarter:$hasStarterModule `
                 -starterTargetPath $starterTargetPath `
-                -starterPipelineFolder $starterPipelineFolder `
                 -starterRelease $starterReleaseTag `
                 -starterConfig $starterConfig `
                 -userInputOverrides $userInputOverrides `


### PR DESCRIPTION
# Pull Request

## Description

We are removing a pipeline path variable that is no longer required.

Here is a successful e2e test run with the updated bootstrap code: https://github.com/Azure/accelerator-bootstrap-modules/actions/runs/9450687525/job/26029889532

These are the sister PRs related to this: 

* https://github.com/Azure/accelerator-bootstrap-modules/pull/23
* https://github.com/Azure/alz-terraform-accelerator/pull/152

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
