### PR TITLE
fix: Correct issue with invalid default value for bicep configs

### DIFF
--- a/docs/wiki/examples/powershell-inputs/inputs-azure-devops-bicep.yaml
+++ b/docs/wiki/examples/powershell-inputs/inputs-azure-devops-bicep.yaml
@@ -34,7 +34,7 @@ apply_approvers: "<email-address-list>"
 create_branch_policies: "true"
 
 # Starter Module Specific Variables
-Prefix: "landing-zone"
+Prefix: "alz"
 Location: "<region>"
 Environment: "live"
 networkType: "hubNetworking"

--- a/docs/wiki/examples/powershell-inputs/inputs-github-bicep.yaml
+++ b/docs/wiki/examples/powershell-inputs/inputs-github-bicep.yaml
@@ -31,7 +31,7 @@ apply_approvers: "<email-address-list>"
 create_branch_policies: "true"
 
 # Starter Module Specific Variables
-Prefix: "landing-zone"
+Prefix: "alz"
 Location: "<region>"
 Environment: "live"
 networkType: "hubNetworking"

--- a/docs/wiki/examples/powershell-inputs/inputs-local-bicep.yaml
+++ b/docs/wiki/examples/powershell-inputs/inputs-local-bicep.yaml
@@ -24,7 +24,7 @@ environment_name: "mgmt"
 postfix_number: "1"
 
 # Starter Module Specific Variables
-Prefix: "landing-zone"
+Prefix: "alz"
 Location: "<region>"
 Environment: "live"
 networkType: "hubNetworking"


### PR DESCRIPTION
# Pull Request

## Issue

Fixes #126 

## Description

This pull request includes changes to three configuration files: `inputs-azure-devops-bicep.yaml`, `inputs-github-bicep.yaml`, and `inputs-local-bicep.yaml`. The changes are all similar, adjusting the `Prefix` value from "landing-zone" to "alz".

* [`docs/wiki/examples/powershell-inputs/inputs-azure-devops-bicep.yaml`](diffhunk://#diff-8ef51d276f1cb7be09e2f79aede3dbdee2557ca16dbfa2b61033ce601a45cc1dL37-R37): The `Prefix` value has been updated from "landing-zone" to "alz".
* [`docs/wiki/examples/powershell-inputs/inputs-github-bicep.yaml`](diffhunk://#diff-cd6e5c8c79a918b84fb1e835f52347eff7178a1714ead3c3461456520e591661L34-R34): The `Prefix` value has been updated from "landing-zone" to "alz".
* [`docs/wiki/examples/powershell-inputs/inputs-local-bicep.yaml`](diffhunk://#diff-65912a94d046c77ca3c2a1314287cacefe507416b10971980a0161e8a9196b94L27-R27): The `Prefix` value has been updated from "landing-zone" to "alz".

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
