### PR TITLE
fix: Bug-132

### DIFF
--- a/src/ALZ/Private/Config-Helpers/Write-TfvarsFile.ps1
+++ b/src/ALZ/Private/Config-Helpers/Write-TfvarsFile.ps1
@@ -23,17 +23,61 @@ function Write-TfvarsFile {
 
             $configurationValue = "`"$($configurationValueRaw)`""
 
-            if($configurationProperty.Value.DataType -eq "list(string)") {
-                if($configurationValueRaw -eq "") {
+            if ($configurationProperty.Value.DataType -eq "list(string)") {
+                if ($configurationValueRaw -eq "") {
                     $configurationValue = "[]"
                 } else {
                     $split = $configurationValueRaw -split ","
                     $join = $split -join "`",`""
                     $configurationValue = "[`"$join`"]"
                 }
+                Write-Host "list(string) - Raw Value: $configurationValueRaw"
             }
 
-            if($configurationProperty.Value.DataType -eq "number" -or $configurationProperty.Value.DataType -eq "bool") {
+            if ($configurationProperty.Value.DataType -eq "map(string)") {
+                if (-not $configurationValueRaw -or $configurationValueRaw.Count -eq 0) {
+                    $configurationValue = "{}"
+                } else {
+                    $configurationValue = "{"
+                    $entries = @()
+
+                    foreach ($key in $configurationValueRaw.Keys) {
+                        $value = $configurationValueRaw[$key]
+                        $entries += "`"$key`": `"$value`""
+                    }
+
+                    $configurationValue = $entries -join ", "
+                    $configurationValue = "{ $configurationValue }"
+                }
+                Write-Host "map(string) - Processed Value: $configurationValue"
+            }
+
+            if ($configurationProperty.Value.DataType -eq "list(object)") {
+                if ($configurationValueRaw -eq "") {
+                    $configurationValue = "[]"
+                } elseif ($configurationValueRaw -eq "[]") {
+                    $configurationValue = "[]"
+                } else {
+                    $configurationValue = "["
+                    foreach ($entry in $configurationValueRaw) {
+                        $configurationValue += "{ "
+                        foreach ($keyValue in $entry.PSObject.Properties) {
+                            $key = $keyValue.Name
+                            $value = $keyValue.Value
+                            $configurationValue += "`"$key`": `"$value`", "
+                        }
+                        $configurationValue = $configurationValue.TrimEnd(", ")
+                        $configurationValue += "}, "
+                    }
+                    $configurationValue = $configurationValue.TrimEnd(", ")
+                    $configurationValue += "]"
+                }
+                Write-Host "list(object) - Raw Value: $configurationValueRaw"
+                Write-Host "list(object) - Processed Value: $configurationValue"
+            }
+
+
+            if ($configurationProperty.Value.DataType -eq "number" -or $configurationProperty.Value.DataType -eq "bool") {
                 $configurationValue = $configurationValueRaw
             } else {
                 $configurationValue = $configurationValue.Replace("\", "\\")


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #132 

## Description


This pull request includes significant enhancements to the `Write-TfvarsFile` function in the `Config-Helpers` module. The changes improve the handling of different data types when writing configuration values, ensuring that default values are used when necessary and that the correct format is applied for lists, maps, and objects.

### Enhancements to `Write-TfvarsFile` function:

* **Improved Handling of List Data Types**:
  - Added a check for empty or null values and applied default values or an empty list (`[]`) as needed. (`src/ALZ/Private/Config-Helpers/Write-TfvarsFile.ps1`)

* **Added Support for Map Data Types**:
  - Introduced logic to handle `map(string)` data types, ensuring that empty maps are represented as `{}` and non-empty maps are properly formatted. (`src/ALZ/Private/Config-Helpers/Write-TfvarsFile.ps1`)

* **Added Support for List of Objects Data Types**:
  - Implemented handling for `list(object)` data types, ensuring that empty lists are represented as `[]` and non-empty lists are correctly formatted with key-value pairs. (`src/ALZ/Private/Config-Helpers/Write-TfvarsFile.ps1`)

## Tests
Test 1:
With this inputs.yaml:
![image](https://github.com/user-attachments/assets/c687c5a0-5e14-4931-a1d3-c3f71f39973e)
and this variables.tf: 
![image](https://github.com/user-attachments/assets/f87d79d7-6627-48d6-a913-53f6aae3c2bb)


Will result in this .tfvars: 
![image](https://github.com/user-attachments/assets/3ade66a1-5186-4bfb-a2d4-f4d250dd7b0e)

Test 2:
With the same variables.tf file from example 1 and inputs.yaml file missing declarations for the complex types:
![image](https://github.com/user-attachments/assets/e0c08316-5e97-4616-9717-a24fd2ade132)

Note: Although the logic to use the default values exists, there is currently an issue $configuration.PSObject.Properties where the defaultvalue is always empty even when a default value exists. Currently something I am looking into further.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
