### PR TITLE
fix: availability zone data type

### DIFF
--- a/src/ALZ/Private/Config-Helpers/Get-AzureRegionData.ps1
+++ b/src/ALZ/Private/Config-Helpers/Get-AzureRegionData.ps1
@@ -25,7 +25,7 @@ module "regions" {
 locals {
   regions = { for region in module.regions.regions_by_name : region.name => {
     display_name = region.display_name
-    zones        = region.zones == null ? [] : region.zones
+    zones        = region.zones == null ? [] : [for zone in region.zones : tostring(zone)]
     }
   }
 }


### PR DESCRIPTION
# Pull Request

## Issue

https://github.com/Azure/ALZ-Bicep/issues/939

## Description

Fix the data type of availability zones as Bicep is expecting an array of strings

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
