### PR TITLE
fix: terraform tool download

### DIFF
--- a/src/ALZ/Private/Tools/Get-TerraformTool.ps1
+++ b/src/ALZ/Private/Tools/Get-TerraformTool.ps1
@@ -13,6 +13,8 @@ function Get-TerraformTool {
             throw "Unable to query Terraform version, please check your internet connection and try again..."
         }
         $version = ($versionResponse).Content | ConvertFrom-Json | Select-Object -ExpandProperty current_version
+        $version = $version.TrimStart("v")
+        Write-Verbose "Latest version of Terraform is $version"
     }
 
     Write-Verbose "Required version of Terraform is $version"


### PR DESCRIPTION
# Pull Request

## Issue

Issue #, if available: https://github.com/Azure/ALZ-PowerShell-Module/issues/311

## Description

HashiCorp updated their release website such that the version string no longer matches. This PR removes the `v` from the version number to make it work again.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
