### PR TITLE
Fix version format for URL

### DIFF
--- a/src/ALZ/Private/Tools/Get-TerraformTool.ps1
+++ b/src/ALZ/Private/Tools/Get-TerraformTool.ps1
@@ -12,7 +12,7 @@ function Get-TerraformTool {
         if($versionResponse.StatusCode -ne "200") {
             throw "Unable to query Terraform version, please check your internet connection and try again..."
         }
-        $version = ($versionResponse).Content | ConvertFrom-Json | Select-Object -ExpandProperty current_version
+        $version = ($versionResponse).Content | ConvertFrom-Json | Select-Object -ExpandProperty current_version | ForEach-Object { $_ -replace '^v', '' }
     }
 
     Write-Verbose "Required version of Terraform is $version"


### PR DESCRIPTION
# Pull Request

## Issue
When TF version is pulled, it has a leading 'v' in front of version number. The constructed URL to download that version of Terraform does not have a leading 'v' in the URL.
Issue #, if available:
#311 
## Description
Removed leading 'v' in version format

Description of changes:

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
