### PR TITLE
fix: avoid empty value of geographyGroup of metadata

### DIFF
--- a/src/ALZ/Private/Config-Helpers/Get-AzureRegionData.ps1
+++ b/src/ALZ/Private/Config-Helpers/Get-AzureRegionData.ps1
@@ -16,7 +16,7 @@ function Get-AzureRegionData {
 
     module "regions" {
     source                    = "Azure/avm-utl-regions/azurerm"
-    version                   = "0.3.0"
+    version                   = "0.5.1"
     use_cached_data           = false
     availability_zones_filter = false
     recommended_filter        = false


### PR DESCRIPTION
# Pull Request

## Issue

Issue #351 

## Description

Description of changes:
Change version of avm-utl-regions to 0.5.1 to avoid empty value of geographyGroup of metadata

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
