### PR TITLE
fix: spelling error when retrieving github release returns an error

### DIFF
--- a/src/ALZ/Private/Shared/Get-GithubRelease.ps1
+++ b/src/ALZ/Private/Shared/Get-GithubRelease.ps1
@@ -73,7 +73,7 @@ function Get-GithubRelease {
 
     # Handle transient errors like throttling
     if($statusCode -ge 400 -and $statusCode -le 599) {
-        Write-InformationColored "Retrying as got the Status Code $statusCode, which may be a tranisent error." -ForegroundColor Yellow -InformationAction Continue
+        Write-InformationColored "Retrying as got the Status Code $statusCode, which may be a transient error." -ForegroundColor Yellow -InformationAction Continue
         $releaseData = Invoke-RestMethod $repoReleaseUrl -RetryIntervalSec 3 -MaximumRetryCount 100
     }
 


### PR DESCRIPTION
# Pull Request

## Issue

Issue #, if available:

## Description

replace "transient" with "transient" in the message displayed when fetching the GitHub release returns an error

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
