### PR TITLE
fix: Expand tilde for chdir (issue #389)

### DIFF
--- a/src/ALZ/Private/Deploy-Accelerator-Helpers/Invoke-Terraform.ps1
+++ b/src/ALZ/Private/Deploy-Accelerator-Helpers/Invoke-Terraform.ps1
@@ -23,10 +23,8 @@ function Invoke-Terraform {
         [switch] $silent
     )
 
-    # Avoid bootstrap Terraform chdir errors if ~ in moduleFolderPath
-    if ($env:HOME -and $env:HOME -ne "" -and $moduleFolderPath -match '^(~)') {
-        $moduleFolderPath = $moduleFolderPath -replace '^(~)', $env:HOME
-    }
+    # Resolve to absolute path for `terraform -chdir` switch
+    $moduleFolderPath = (Resolve-Path $moduleFolderPath).Path
 
     if ($PSCmdlet.ShouldProcess("Apply Terraform", "modify")) {
         # Check and Set Subscription ID

--- a/src/ALZ/Private/Deploy-Accelerator-Helpers/Invoke-Terraform.ps1
+++ b/src/ALZ/Private/Deploy-Accelerator-Helpers/Invoke-Terraform.ps1
@@ -23,6 +23,11 @@ function Invoke-Terraform {
         [switch] $silent
     )
 
+    # Avoid bootstrap Terraform chdir errors if ~ in moduleFolderPath
+    if ($env:HOME -and $env:HOME -ne "" -and $moduleFolderPath -match '^(~)') {
+        $moduleFolderPath = $moduleFolderPath -replace '^(~)', $env:HOME
+    }
+
     if ($PSCmdlet.ShouldProcess("Apply Terraform", "modify")) {
         # Check and Set Subscription ID
         $removeSubscriptionId = $false


### PR DESCRIPTION
# Pull Request

## Issue

Fixes #389

## Description

Expands ~ with $env:HOME if found in moduleFolderPath

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
