### PR TITLE
fix: type check for array

### DIFF
--- a/src/ALZ/Private/Config-Helpers/Set-Config.ps1
+++ b/src/ALZ/Private/Config-Helpers/Set-Config.ps1
@@ -60,7 +60,7 @@ function Set-Config {
                         # Handle integer index for arrays
                         Write-Verbose "Handling integer index for array"
 
-                        if(!$inputConfigItemValueType.EndsWith("[]")) {
+                        if(!$inputConfigItemValueType.EndsWith("[]") -and !$inputConfigItemValueType.StartsWith("System.Collections.Generic.List")) {
                             Write-Error "Input config item $($inputConfigName) is not an array, but an index was specified."
                             throw "Input config item $($inputConfigName) is not an array, but an index was specified."
                         }


### PR DESCRIPTION
# Pull Request

## Issue

Azure/Azure-Landing-Zones#2353

## Description

Type check for array not working in all circumstances. Adding check for generic list

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
