### PR TITLE
fix: handle single item array

### DIFF
--- a/src/ALZ/Private/Config-Helpers/Set-Config.ps1
+++ b/src/ALZ/Private/Config-Helpers/Set-Config.ps1
@@ -65,6 +65,12 @@ function Set-Config {
                         # Handle integer index for arrays
                         Write-Verbose "Handling integer index for array"
 
+                        # Ensure single value array is treated as array
+                        if(!$inputConfigItemValueType.EndsWith("]")) {
+                            Write-Verbose "Converting single value to array for input config item $($inputConfigName)."
+                            $inputConfigItemValue = @($inputConfigItemValue)
+                        }
+
                         $index = [int]$indexString
                         if($inputConfigItemValue.Length -le $index) {
                             Write-Verbose "Input config item $($inputConfigName) does not have an index of $index."


### PR DESCRIPTION
# Pull Request

## Issue

Issue #, if available: https://github.com/Azure/ALZ-PowerShell-Module/issues/412#issuecomment-3314146600

## Description

PowerShell Convert commands unboxes single item arrays, we need to handle that for the single item array (e.g. single region)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
