### PR TITLE
fix: update ALZ module version checks to use Get-InstalledPSResource

### DIFF
--- a/src/ALZ/Private/Tools/Test-Tooling.ps1
+++ b/src/ALZ/Private/Tools/Test-Tooling.ps1
@@ -160,7 +160,8 @@ function Test-Tooling {
     } else {
         # Check if latest ALZ module is installed
         Write-Verbose "Checking ALZ module version"
-        $alzModuleCurrentVersion = Get-InstalledModule -Name ALZ -ErrorAction SilentlyContinue
+        $alzModuleCurrentVersion = Get-InstalledPSResource -Name ALZ | Select-Object -Property Name, Version
+
         if($null -eq $alzModuleCurrentVersion) {
             $checkResults += @{
                 message = "ALZ module is not correctly installed. Please install the latest version using 'Install-Module ALZ'."
@@ -168,7 +169,7 @@ function Test-Tooling {
             }
             $hasFailure = $true
         }
-        $alzModuleLatestVersion = Find-Module -Name ALZ
+        $alzModuleLatestVersion = Find-PSResource -Name ALZ
         if ($null -ne $alzModuleCurrentVersion) {
             if ($alzModuleCurrentVersion.Version -lt $alzModuleLatestVersion.Version) {
                 $checkResults += @{


### PR DESCRIPTION
# Pull Request

## Issue

Issue #, if available:
https://github.com/Azure/Azure-Landing-Zones/issues/2324

## Description

Description of changes:

This pull request updates the way the ALZ module is checked and retrieved in the `Test-Tooling` function, modernizing the approach to use the latest PowerShell resource management cmdlets for better compatibility and reliability.

**Module management modernization:**

* Replaced `Get-InstalledModule` with `Get-InstalledPSResource` for checking the installed ALZ module version, and updated the selection of properties to include `Name` and `Version`.
* Replaced `Find-Module` with `Find-PSResource` for retrieving the latest available ALZ module version.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
