### PR TITLE
Bugfix: Test-Tooling - Sort ALZ module versions and select the latest

### DIFF
--- a/src/ALZ/Private/Tools/Test-Tooling.ps1
+++ b/src/ALZ/Private/Tools/Test-Tooling.ps1
@@ -160,7 +160,7 @@ function Test-Tooling {
     } else {
         # Check if latest ALZ module is installed
         Write-Verbose "Checking ALZ module version"
-        $alzModuleCurrentVersion = Get-InstalledPSResource -Name ALZ | Select-Object -Property Name, Version
+        $alzModuleCurrentVersion = Get-InstalledPSResource -Name ALZ | Select-Object -Property Name, Version | Sort-Object Version -Descending | Select-Object -First 1
 
         if($null -eq $alzModuleCurrentVersion) {
             $checkResults += @{


### PR DESCRIPTION
# Pull Request

## Issue
When a user have installed the module via both Install-Module and Install-PSResource, the current logic returns two objects and breaks the logic who detects the installed version:
<img width="1486" height="230" alt="image" src="https://github.com/user-attachments/assets/404b77ad-7ee4-4bbd-bfdd-c234ed108fa4" />

Issue #, if available:
https://github.com/Azure/Azure-Landing-Zones/issues/2324

## Description

This pull request fixes the issue by selecting the latest installed version independently of how it was installed.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
