### PR TITLE
refactor: extract Terraform scenarios to JSON config and add SMB scenarios

### DIFF
--- a/src/ALZ/Private/Deploy-Accelerator-Helpers/AcceleratorInputSchema.json
+++ b/src/ALZ/Private/Deploy-Accelerator-Helpers/AcceleratorInputSchema.json
@@ -28,8 +28,8 @@
           "type": "object",
           "required": true,
           "properties": {
-            "management": {
-              "description": "The subscription ID for the Management subscription where logging, monitoring, and automation resources will be deployed",
+            "connectivity": {
+              "description": "The subscription ID for the Connectivity subscription where networking resources like hubs, firewalls, and DNS will be deployed",
               "type": "guid",
               "required": true,
               "source": "subscription"
@@ -37,11 +37,11 @@
             "identity": {
               "description": "The subscription ID for the Identity subscription where identity resources like domain controllers will be deployed",
               "type": "guid",
-              "required": true,
+              "required": false,
               "source": "subscription"
             },
-            "connectivity": {
-              "description": "The subscription ID for the Connectivity subscription where networking resources like hubs, firewalls, and DNS will be deployed",
+            "management": {
+              "description": "The subscription ID for the Management subscription where logging, monitoring, and automation resources will be deployed",
               "type": "guid",
               "required": true,
               "source": "subscription"
@@ -49,7 +49,7 @@
             "security": {
               "description": "The subscription ID for the Security subscription where security monitoring and governance resources will be deployed",
               "type": "guid",
-              "required": true,
+              "required": false,
               "source": "subscription"
             }
           }

--- a/src/ALZ/Private/Deploy-Accelerator-Helpers/Request-ALZConfigurationValue.ps1
+++ b/src/ALZ/Private/Deploy-Accelerator-Helpers/Request-ALZConfigurationValue.ps1
@@ -127,6 +127,11 @@ function Request-ALZConfigurationValue {
             $menuParams.ManualEntryPrompt = "Enter subscription ID"
             $menuParams.RequiredMessage = "This field is required. Please select a subscription."
             $menuParams.EmptyMessage = "No subscriptions found in Azure context."
+            if (-not $isRequired) {
+                $menuParams.ManualEntryLabel = "Enter manually or don't supply"
+                $menuParams.DefaultToManualEntry = $true
+                $menuParams.DefaultValue = ""
+            }
         } elseif ($source -eq "managementGroup") {
             $menuParams.OptionsTitle = "Available management groups:"
             $menuParams.Options = $AzureContext.ManagementGroups
@@ -252,15 +257,13 @@ function Request-ALZConfigurationValue {
                         continue
                     }
 
-                    foreach ($subKey in @($currentValue.Keys)) {
-                        $subCurrentValue = $currentValue[$subKey]
-                        $subSchemaInfo = $null
-
-                        if ($nestedSchema.PSObject.Properties.Name -contains $subKey) {
-                            $subSchemaInfo = $nestedSchema.$subKey
-                        } else {
+                    # Iterate using schema property order to ensure consistent display ordering
+                    foreach ($subKey in @($nestedSchema.PSObject.Properties.Name)) {
+                        if (-not $currentValue.Contains($subKey)) {
                             continue
                         }
+                        $subCurrentValue = $currentValue[$subKey]
+                        $subSchemaInfo = $nestedSchema.$subKey
 
                         $result = Read-InputValue -Key $subKey -CurrentValue $subCurrentValue -SchemaInfo $subSchemaInfo -DefaultDescription "$key - $subKey" -AzureContext $AzureContext
                         $subNewValue = $result.Value

--- a/src/ALZ/Private/Deploy-Accelerator-Helpers/Request-AcceleratorConfigurationInput.ps1
+++ b/src/ALZ/Private/Deploy-Accelerator-Helpers/Request-AcceleratorConfigurationInput.ps1
@@ -161,17 +161,8 @@ function Request-AcceleratorConfigurationInput {
 
             # Prompt for scenario number (Terraform only)
             if ($selectedIacType -eq "terraform") {
-                $scenarioOptions = @(
-                    @{ label = "1 - Full Multi-Region - Hub and Spoke VNet"; value = 1 },
-                    @{ label = "2 - Full Multi-Region - Virtual WAN"; value = 2 },
-                    @{ label = "3 - Full Multi-Region NVA - Hub and Spoke VNet"; value = 3 },
-                    @{ label = "4 - Full Multi-Region NVA - Virtual WAN"; value = 4 },
-                    @{ label = "5 - Management Only"; value = 5 },
-                    @{ label = "6 - Full Single-Region - Hub and Spoke VNet"; value = 6 },
-                    @{ label = "7 - Full Single-Region - Virtual WAN"; value = 7 },
-                    @{ label = "8 - Full Single-Region NVA - Hub and Spoke VNet"; value = 8 },
-                    @{ label = "9 - Full Single-Region NVA - Virtual WAN"; value = 9 }
-                )
+                $scenariosJsonPath = Join-Path $PSScriptRoot "TerraformScenarios.json"
+                $scenarioOptions = Get-Content -Path $scenariosJsonPath -Raw | ConvertFrom-Json
 
                 $selectedScenarioNumber = Read-MenuSelection `
                     -Title "Select the Terraform scenario (see https://aka.ms/alz/acc/scenarios):" `

--- a/src/ALZ/Private/Deploy-Accelerator-Helpers/TerraformScenarios.json
+++ b/src/ALZ/Private/Deploy-Accelerator-Helpers/TerraformScenarios.json
@@ -1,0 +1,13 @@
+[
+    { "label": "1 - Full Multi-Region - Hub and Spoke VNet", "value": 1 },
+    { "label": "2 - Full Multi-Region - Virtual WAN", "value": 2 },
+    { "label": "3 - Full Multi-Region NVA - Hub and Spoke VNet", "value": 3 },
+    { "label": "4 - Full Multi-Region NVA - Virtual WAN", "value": 4 },
+    { "label": "5 - Management Only", "value": 5 },
+    { "label": "6 - Full Single-Region - Hub and Spoke VNet", "value": 6 },
+    { "label": "7 - Full Single-Region - Virtual WAN", "value": 7 },
+    { "label": "8 - Full Single-Region NVA - Hub and Spoke VNet", "value": 8 },
+    { "label": "9 - Full Single-Region NVA - Virtual WAN", "value": 9 },
+    { "label": "10 - SMB Single-Region - Hub and Spoke VNet", "value": 10 },
+    { "label": "11 - SMB Single-Region - Virtual WAN", "value": 11 }
+]

--- a/src/ALZ/Private/Shared/Read-MenuSelection.ps1
+++ b/src/ALZ/Private/Shared/Read-MenuSelection.ps1
@@ -74,6 +74,12 @@ function Read-MenuSelection {
         [switch] $AllowManualEntry,
 
         [Parameter(Mandatory = $false)]
+        [string] $ManualEntryLabel = "Enter manually",
+
+        [Parameter(Mandatory = $false)]
+        [switch] $DefaultToManualEntry,
+
+        [Parameter(Mandatory = $false)]
         [string] $ManualEntryPrompt = "Enter value",
 
         [Parameter(Mandatory = $false)]
@@ -331,7 +337,12 @@ function Read-MenuSelection {
 
     # Show manual entry option if allowed
     if ($AllowManualEntry.IsPresent) {
-        Write-ToConsoleLog "[0] Enter manually" -IsSelection -IndentLevel 1
+        $manualEntryMarker = if ($DefaultToManualEntry.IsPresent) { " (current)" } else { "" }
+        if ($DefaultToManualEntry.IsPresent) {
+            Write-ToConsoleLog "[0] $ManualEntryLabel$manualEntryMarker" -IsSelection -Color Green -IndentLevel 1
+        } else {
+            Write-ToConsoleLog "[0] $ManualEntryLabel" -IsSelection -IndentLevel 1
+        }
     }
 
     # Build prompt text
@@ -340,7 +351,11 @@ function Read-MenuSelection {
     if ($AllowManualEntry.IsPresent) {
         $promptText += ", 0 for manual entry"
     }
-    $promptText += ", default: $($DefaultIndex + 1))"
+    if ($DefaultToManualEntry.IsPresent) {
+        $promptText += ", default: 0)"
+    } else {
+        $promptText += ", default: $($DefaultIndex + 1))"
+    }
 
     # Get selection
     $result = $null
@@ -348,8 +363,13 @@ function Read-MenuSelection {
         $selection = Read-InputValue -Prompt $promptText -Sensitive $IsSensitive.IsPresent
 
         if ([string]::IsNullOrWhiteSpace($selection)) {
-            # Use default
-            $result = Get-OptionValue -Option $Options[$DefaultIndex]
+            if ($DefaultToManualEntry.IsPresent) {
+                # Default to manual entry - return DefaultValue (empty string)
+                $result = if ($null -ne $DefaultValue) { $DefaultValue } else { "" }
+            } else {
+                # Use default option
+                $result = Get-OptionValue -Option $Options[$DefaultIndex]
+            }
         } elseif ($AllowManualEntry.IsPresent -and $selection -eq "0") {
             # Manual entry
             do {


### PR DESCRIPTION
## Summary

https://github.com/Azure/Azure-Landing-Zones/issues/4095

Extract the hardcoded Terraform scenario options from `Request-AcceleratorConfigurationInput.ps1` into a dedicated `TerraformScenarios.json` config file, making it easier to add, remove, or update scenarios without modifying PowerShell code.

## Changes

- **New file**: `TerraformScenarios.json` - JSON array of scenario objects with `label` and `value` properties
- **Modified**: `Request-AcceleratorConfigurationInput.ps1` - loads scenarios from the JSON file via `ConvertFrom-Json` instead of inline array
- **Added scenarios 10-11**: SMB Single-Region Hub and Spoke VNet / Virtual WAN (per Azure/alz-terraform-accelerator#305)