### PR TITLE
feat: add SMB scenarios 10 and 11, load scenarios from JSON config

### DIFF
--- a/src/ALZ/Private/Deploy-Accelerator-Helpers/TerraformScenarios.json
+++ b/src/ALZ/Private/Deploy-Accelerator-Helpers/TerraformScenarios.json
@@ -1,13 +1,13 @@
 [
-    { "label": "1 - Full Multi-Region - Hub and Spoke VNet", "value": 1, "path": "full-multi-region/hub-and-spoke-vnet.tfvars" },
-    { "label": "2 - Full Multi-Region - Virtual WAN", "value": 2, "path": "full-multi-region/virtual-wan.tfvars" },
-    { "label": "3 - Full Multi-Region NVA - Hub and Spoke VNet", "value": 3, "path": "full-multi-region-nva/hub-and-spoke-vnet.tfvars" },
-    { "label": "4 - Full Multi-Region NVA - Virtual WAN", "value": 4, "path": "full-multi-region-nva/virtual-wan.tfvars" },
-    { "label": "5 - Management Only", "value": 5, "path": "management-only/management.tfvars" },
-    { "label": "6 - Full Single-Region - Hub and Spoke VNet", "value": 6, "path": "full-single-region/hub-and-spoke-vnet.tfvars" },
-    { "label": "7 - Full Single-Region - Virtual WAN", "value": 7, "path": "full-single-region/virtual-wan.tfvars" },
-    { "label": "8 - Full Single-Region NVA - Hub and Spoke VNet", "value": 8, "path": "full-single-region-nva/hub-and-spoke-vnet.tfvars" },
-    { "label": "9 - Full Single-Region NVA - Virtual WAN", "value": 9, "path": "full-single-region-nva/virtual-wan.tfvars" },
-    { "label": "10 - SMB Single-Region - Hub and Spoke VNet", "value": 10, "path": "smb-single-region/hub-and-spoke-vnet.tfvars" },
-    { "label": "11 - SMB Single-Region - Virtual WAN", "value": 11, "path": "smb-single-region/virtual-wan.tfvars" }
+    { "label": "Full Multi-Region - Hub and Spoke VNet", "value": 1, "path": "full-multi-region/hub-and-spoke-vnet.tfvars" },
+    { "label": "Full Multi-Region - Virtual WAN", "value": 2, "path": "full-multi-region/virtual-wan.tfvars" },
+    { "label": "Full Multi-Region NVA - Hub and Spoke VNet", "value": 3, "path": "full-multi-region-nva/hub-and-spoke-vnet.tfvars" },
+    { "label": "Full Multi-Region NVA - Virtual WAN", "value": 4, "path": "full-multi-region-nva/virtual-wan.tfvars" },
+    { "label": "Management Only", "value": 5, "path": "management-only/management.tfvars" },
+    { "label": "Full Single-Region - Hub and Spoke VNet", "value": 6, "path": "full-single-region/hub-and-spoke-vnet.tfvars" },
+    { "label": "Full Single-Region - Virtual WAN", "value": 7, "path": "full-single-region/virtual-wan.tfvars" },
+    { "label": "Full Single-Region NVA - Hub and Spoke VNet", "value": 8, "path": "full-single-region-nva/hub-and-spoke-vnet.tfvars" },
+    { "label": "Full Single-Region NVA - Virtual WAN", "value": 9, "path": "full-single-region-nva/virtual-wan.tfvars" },
+    { "label": "SMB Single-Region - Hub and Spoke VNet", "value": 10, "path": "smb-single-region/hub-and-spoke-vnet.tfvars" },
+    { "label": "SMB Single-Region - Virtual WAN", "value": 11, "path": "smb-single-region/virtual-wan.tfvars" }
 ]

--- a/src/ALZ/Private/Deploy-Accelerator-Helpers/TerraformScenarios.json
+++ b/src/ALZ/Private/Deploy-Accelerator-Helpers/TerraformScenarios.json
@@ -1,13 +1,13 @@
 [
-    { "label": "1 - Full Multi-Region - Hub and Spoke VNet", "value": 1 },
-    { "label": "2 - Full Multi-Region - Virtual WAN", "value": 2 },
-    { "label": "3 - Full Multi-Region NVA - Hub and Spoke VNet", "value": 3 },
-    { "label": "4 - Full Multi-Region NVA - Virtual WAN", "value": 4 },
-    { "label": "5 - Management Only", "value": 5 },
-    { "label": "6 - Full Single-Region - Hub and Spoke VNet", "value": 6 },
-    { "label": "7 - Full Single-Region - Virtual WAN", "value": 7 },
-    { "label": "8 - Full Single-Region NVA - Hub and Spoke VNet", "value": 8 },
-    { "label": "9 - Full Single-Region NVA - Virtual WAN", "value": 9 },
-    { "label": "10 - SMB Single-Region - Hub and Spoke VNet", "value": 10 },
-    { "label": "11 - SMB Single-Region - Virtual WAN", "value": 11 }
+    { "label": "1 - Full Multi-Region - Hub and Spoke VNet", "value": 1, "path": "full-multi-region/hub-and-spoke-vnet.tfvars" },
+    { "label": "2 - Full Multi-Region - Virtual WAN", "value": 2, "path": "full-multi-region/virtual-wan.tfvars" },
+    { "label": "3 - Full Multi-Region NVA - Hub and Spoke VNet", "value": 3, "path": "full-multi-region-nva/hub-and-spoke-vnet.tfvars" },
+    { "label": "4 - Full Multi-Region NVA - Virtual WAN", "value": 4, "path": "full-multi-region-nva/virtual-wan.tfvars" },
+    { "label": "5 - Management Only", "value": 5, "path": "management-only/management.tfvars" },
+    { "label": "6 - Full Single-Region - Hub and Spoke VNet", "value": 6, "path": "full-single-region/hub-and-spoke-vnet.tfvars" },
+    { "label": "7 - Full Single-Region - Virtual WAN", "value": 7, "path": "full-single-region/virtual-wan.tfvars" },
+    { "label": "8 - Full Single-Region NVA - Hub and Spoke VNet", "value": 8, "path": "full-single-region-nva/hub-and-spoke-vnet.tfvars" },
+    { "label": "9 - Full Single-Region NVA - Virtual WAN", "value": 9, "path": "full-single-region-nva/virtual-wan.tfvars" },
+    { "label": "10 - SMB Single-Region - Hub and Spoke VNet", "value": 10, "path": "smb-single-region/hub-and-spoke-vnet.tfvars" },
+    { "label": "11 - SMB Single-Region - Virtual WAN", "value": 11, "path": "smb-single-region/virtual-wan.tfvars" }
 ]

--- a/src/ALZ/Public/New-AcceleratorFolderStructure.ps1
+++ b/src/ALZ/Public/New-AcceleratorFolderStructure.ps1
@@ -130,16 +130,11 @@ function New-AcceleratorFolderStructure {
 
         # Copy the platform landing zone configuration files based on scenario number or specific file path
         if ($repo.hasScenarios) {
-            $scenarios = @{
-                1 = "full-multi-region/hub-and-spoke-vnet.tfvars"
-                2 = "full-multi-region/virtual-wan.tfvars"
-                3 = "full-multi-region-nva/hub-and-spoke-vnet.tfvars"
-                4 = "full-multi-region-nva/virtual-wan.tfvars"
-                5 = "management-only/management.tfvars"
-                6 = "full-single-region/hub-and-spoke-vnet.tfvars"
-                7 = "full-single-region/virtual-wan.tfvars"
-                8 = "full-single-region-nva/hub-and-spoke-vnet.tfvars"
-                9 = "full-single-region-nva/virtual-wan.tfvars"
+            $scenariosJsonPath = Join-Path $PSScriptRoot ".." "Private" "Deploy-Accelerator-Helpers" "TerraformScenarios.json"
+            $scenarioOptions = Get-Content -Path $scenariosJsonPath -Raw | ConvertFrom-Json
+            $scenarios = @{}
+            foreach ($scenario in $scenarioOptions) {
+                $scenarios[[int]$scenario.value] = $scenario.path
             }
 
             Write-ToConsoleLog "Copying platform landing zone configuration file for scenario $scenarioNumber to $($targetFolderPath)/config/platform-landing-zone.tfvars"


### PR DESCRIPTION
## Summary

Adds missing SMB scenarios 10 and 11 to the accelerator folder structure creation, and refactors scenario management to use the existing `TerraformScenarios.json` config file as the single source of truth.

Closes Azure/Azure-Landing-Zones#4105

## Changes

### TerraformScenarios.json
- Added `path` property to each scenario entry, mapping scenario numbers to their tfvars file paths
- Scenarios 10 and 11 were already present (labels only) — now they also have paths:
  - **10**: `smb-single-region/hub-and-spoke-vnet.tfvars`
  - **11**: `smb-single-region/virtual-wan.tfvars`

### New-AcceleratorFolderStructure.ps1
- Replaced hardcoded `` hashtable with dynamic loading from `TerraformScenarios.json`
- Fixed `int64`/`int32` type mismatch when looking up scenario paths (JSON parser returns `int64`, parameter is `[int]`/`int32` — without the cast, hashtable lookup returns `` and `Copy-Item` creates a directory instead of copying the file)